### PR TITLE
CLI serving tool

### DIFF
--- a/outlines/function.py
+++ b/outlines/function.py
@@ -3,12 +3,37 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
 
 import requests
+from pydantic import RootModel
 
 from outlines import generate, models
 
 if TYPE_CHECKING:
     from outlines.generate.api import SequenceGenerator
     from outlines.prompts import Prompt
+
+
+class NewFunction:
+    """Represents an Outlines function.
+
+    Functions are a convenient way to encapsulate a prompt template, a language
+    model and a Pydantic model that define the output structure. Once defined,
+    the function can be called with arguments that will be used to render the
+    prompt template.
+
+    """
+
+    model: str
+    prompt_template: Optional[Callable] = None
+    pydantic_schema: Optional[RootModel] = None
+
+    def prompt(self, fn: Callable):
+        pass
+
+    def schema(self, model: RootModel):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        pass
 
 
 @dataclass

--- a/outlines/serve/main.py
+++ b/outlines/serve/main.py
@@ -1,0 +1,42 @@
+import typer
+from typing_extensions import Annotated
+
+from outlines.function import extract_function_from_file
+
+app = typer.Typer(
+    no_args_is_help=True, help="Serve Outlines functions as APIs", add_completion=False
+)
+
+
+@app.command()
+def serve(
+    path: Annotated[
+        str,
+        typer.Argument(help="Path to the script that defines the Outlines function."),
+    ],
+    name: Annotated[
+        str,
+        typer.Option("--name", "-n", help="The name of the function in the script."),
+    ] = "fn",
+    port: Annotated[
+        int,
+        typer.Option("--port", "-p", help="Port to serve the function locally"),
+    ] = 8000,
+):
+    """Serve the Outlines function."""
+
+    with open(path) as file:
+        content = file.read()
+
+    _ = extract_function_from_file(content, name)
+
+    # 1. Load the file and import objects
+    # 2. Find the function by its name
+    # 3. Create an API based on the prompt function's parameters and model name
+    # 4. Return example of calling the API
+
+    print(f"{path}{port}{name}")
+
+
+def main():
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ serve = [
     "uvicorn",
     "fastapi",
     "pydantic>=2.0",
+    "typer[all]",
 ]
 
 [project.urls]
@@ -75,6 +76,9 @@ repository = "https://github.com/outlines-dev/outlines"
 [project.readme]
 file="README.md"
 content-type = "text/markdown"
+
+[project.scripts]
+outlines = "outlines.serve.main:main"
 
 [tool.setuptools]
 packages = ["outlines"]
@@ -94,6 +98,9 @@ filterwarnings = [
     "ignore::FutureWarning:transformers.*",
     "ignore::UserWarning",
 ]
+
+[tool.poetry.scripts]
+rick-portal-gun = "rick_portal_gun.main:app"
 
 [tool.mypy]
 exclude=["examples"]
@@ -117,6 +124,7 @@ module = [
     "tiktoken.*",
     "torch.*",
     "transformers.*",
+    "typer.*",
     "llama_cpp",
     "huggingface_hub",
     "lark.*",


### PR DESCRIPTION
In this PR I introduce an `outlines` command-line interface which allows users to serve locally JSON-structured generation workflows. The workflows consists in a prompt template, a LLM and a Pydantic model. The API's parameters are the prompt template's arguments and it returns a JSON object that respect the JSON Schema implicitly defined by the Pydantic model. 

The use of the CLI is as follows:

```bash
outlines serve [SCRIPT] [--port 8000] [--name fn]
```

I am still not sure whether serving should happen via llama.cpp or vLLM. The interface to define the API using Outlines is also not completely defined:

```python
from pydantic import BaseModel
import outlines


fn = outlines.Function("mistralai/Mistral-7B-v0.1")

@fn.prompt
def prompt_template(arg):
    """{arg}}"""
    
@fn.schema
class Schema(BaseModel):
    foo: int
    bar: str
```

It should also be possible to call the thus defined function from another script.