### PR TITLE
Adds option for JSON schema optimization

### DIFF
--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -97,7 +97,7 @@ def build_regex_from_schema(
     return to_regex(resolver, content, whitespace_pattern)
 
 
-def is_null_type(instance: dict):
+def _is_null_type(instance: dict):
     if "type" in instance and (instance["type"] == "null" or instance["type"] is None):
         return True
     if "const" in instance and (
@@ -107,9 +107,9 @@ def is_null_type(instance: dict):
     return False
 
 
-def any_of_list_has_null_type(any_of_list: list[dict[str, str]]):
-    for subinstance in any_of_list:
-        if is_null_type(subinstance):
+def _has_null_type(instance_list: list[dict]):
+    for instance in instance_list:
+        if _is_null_type(instance):
             return True
     return False
 
@@ -134,12 +134,10 @@ def optimize_schema(instance):
                     subinstance_type == "array" and subinstance.get("minItems", 0) == 0
                 ):
                     new_optional_keys.add(key)
-            elif "anyOf" in subinstance and any_of_list_has_null_type(
-                subinstance["anyOf"]
-            ):
+            elif "anyOf" in subinstance and _has_null_type(subinstance["anyOf"]):
                 any_of_list = subinstance.pop("anyOf")
                 filtered_any_of_list = list(
-                    filter(lambda d: is_null_type(d), any_of_list)
+                    filter(lambda d: _is_null_type(d), any_of_list)
                 )
                 if len(filtered_any_of_list) == 0:
                     keys_to_remove.add(key)

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -137,7 +137,7 @@ def optimize_schema(instance):
             elif "anyOf" in subinstance and _has_null_type(subinstance["anyOf"]):
                 any_of_list = subinstance.pop("anyOf")
                 filtered_any_of_list = list(
-                    filter(lambda d: _is_null_type(d), any_of_list)
+                    filter(lambda d: not _is_null_type(d), any_of_list)
                 )
                 if len(filtered_any_of_list) == 0:
                     keys_to_remove.add(key)

--- a/outlines/fsm/json_schema.py
+++ b/outlines/fsm/json_schema.py
@@ -3,7 +3,7 @@ import json
 import re
 import warnings
 from copy import deepcopy
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from jsonschema.protocols import Validator
 from pydantic import create_model
@@ -107,7 +107,7 @@ def _is_null_type(instance: dict):
     return False
 
 
-def _has_null_type(instance_list: list[dict]):
+def _has_null_type(instance_list: List[dict]):
     for instance in instance_list:
         if _is_null_type(instance):
             return True

--- a/outlines/integrations/llamacpp.py
+++ b/outlines/integrations/llamacpp.py
@@ -171,6 +171,7 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
         schema: Union[dict, Type[BaseModel], str],
         llm: "Llama",
         whitespace_pattern: Optional[str] = None,
+        enable_schema_optimization: bool = False,
     ):
         """Compile the FSM that drives the JSON-guided generation.
 
@@ -184,9 +185,17 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
             Pattern to use for JSON syntactic whitespace (doesn't impact string
             literals). For example, to allow only a single space or newline with
             `whitespace_pattern=r"[\n ]?"`
+        enable_schema_optimization
+            If True, this will speed up generation by not requiring optional keys to be
+            present in the output. This is especially useful for large schemas with many
+            optional keys. Note though that this further restricts the support
+            distribution. Thus, it is necessary to remove the optional keys from the
+            finetuning dataset as well if needed. Hence, we set this to False by default.
         """
         schema_str = convert_json_schema_to_str(json_schema=schema)
-        regex_string = build_regex_from_schema(schema_str, whitespace_pattern)
+        regex_string = build_regex_from_schema(
+            schema_str, whitespace_pattern, enable_schema_optimization
+        )
         super().__init__(regex_string=regex_string, llm=llm)
 
 

--- a/outlines/integrations/transformers.py
+++ b/outlines/integrations/transformers.py
@@ -140,6 +140,7 @@ class JSONPrefixAllowedTokens(RegexPrefixAllowedTokens):
         schema: Union[dict, Type[BaseModel], str],
         tokenizer_or_pipe: Union[PreTrainedTokenizerBase, Pipeline],
         whitespace_pattern: Optional[str] = None,
+        enable_schema_optimization: bool = False,
     ):
         """Compile the FSM that drives the JSON-guided generation.
 
@@ -153,7 +154,15 @@ class JSONPrefixAllowedTokens(RegexPrefixAllowedTokens):
             Pattern to use for JSON syntactic whitespace (doesn't impact string
             literals). For example, to allow only a single space or newline with
             `whitespace_pattern=r"[\n ]?"`
+        enable_schema_optimization:
+            If True, this will speed up generation by not requiring optional keys to be
+            present in the output. This is especially useful for large schemas with many
+            optional keys. Note though that this further restricts the support
+            distribution. Thus, it is necessary to remove the optional keys from the
+            finetuning dataset as well if needed. Hence, we set this to False by default.
         """
         schema_str = convert_json_schema_to_str(json_schema=schema)
-        regex_string = build_regex_from_schema(schema_str, whitespace_pattern)
+        regex_string = build_regex_from_schema(
+            schema_str, whitespace_pattern, enable_schema_optimization
+        )
         super().__init__(regex_string=regex_string, tokenizer_or_pipe=tokenizer_or_pipe)

--- a/outlines/integrations/vllm.py
+++ b/outlines/integrations/vllm.py
@@ -132,6 +132,7 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
         schema: Union[dict, Type[BaseModel], str],
         llm: "LLM",
         whitespace_pattern: Optional[str] = None,
+        enable_schema_optimization: bool = False,
     ):
         """Compile the FSM that drives the JSON-guided generation.
 
@@ -145,7 +146,15 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
             Pattern to use for JSON syntactic whitespace (doesn't impact string
             literals). For example, to allow only a single space or newline with
             `whitespace_pattern=r"[\n ]?"`
+        enable_schema_optimization:
+            If True, this will speed up generation by not requiring optional keys to be
+            present in the output. This is especially useful for large schemas with many
+            optional keys. Note though that this further restricts the support
+            distribution. Thus, it is necessary to remove the optional keys from the
+            finetuning dataset as well if needed. Hence, we set this to False by default.
         """
         schema_str = convert_json_schema_to_str(json_schema=schema)
-        regex_string = build_regex_from_schema(schema_str, whitespace_pattern)
+        regex_string = build_regex_from_schema(
+            schema_str, whitespace_pattern, enable_schema_optimization
+        )
         super().__init__(regex_string=regex_string, llm=llm)

--- a/outlines/serve/serve.py
+++ b/outlines/serve/serve.py
@@ -68,8 +68,17 @@ async def generate(request: Request) -> Response:
 
     json_schema = request_dict.pop("schema", None)
     regex_string = request_dict.pop("regex", None)
+    whitespace_pattern = request_dict.pop("whitespace_pattern", None)
+    enable_schema_optimization = request_dict.pop("enable_schema_optimization", False)
     if json_schema is not None:
-        logits_processors = [JSONLogitsProcessor(json_schema, engine.engine)]
+        logits_processors = [
+            JSONLogitsProcessor(
+                json_schema,
+                engine.engine,
+                whitespace_pattern,
+                enable_schema_optimization,
+            )
+        ]
     elif regex_string is not None:
         logits_processors = [RegexLogitsProcessor(regex_string, engine.engine)]
     else:


### PR DESCRIPTION
Pydantic's `.model_json_schema()` and `get_schema_from_signature` don't actually make optional fields/arguments optional in the json schema. This forces the model to output the keys even when the values are `null` anyway--slowing down inference the larger the schema is & the more optional fields there is.

---

For example, for this Pydantic class:

```python
class Test(BaseModel):
    field_a: int
    field_b: Optional[int]
    field_c: None
```

`.model_json_schema()` builds this schema:

```json
{
    "properties": {
        "field_a": {"title": "Field A", "type": "integer"},
        "field_b": {
            "anyOf": [{"type": "integer"}, {"type": "null"}],
            "title": "Field B",
        },
        "field_c": {"title": "Field C", "type": "null"},
    },
    "required": ["field_a", "field_b", "field_c"],
    "title": "Test",
    "type": "object",
}
```

`optimize_schema` in this PR reduces this to:

```json
{
    "properties": {
        "field_a": {"title": "Field A", "type": "integer"},
        "field_b": {"title": "Field B", "type": "integer"},
    },
    "required": ["field_a"],
    "title": "Test",
    "type": "object",
}
```

---

Likewise, `get_schema_from_signature` converts this function:

```python
def test_add(a: int, b: int | None = None):
    if b is None:
        return a
    return a + b
```

to this schema:

```json
{
    "properties": {
        "a": {"title": "A", "type": "integer"},
        "b": {
            "anyOf": [{"type": "integer"}, {"type": "null"}],
            "title": "B",
        },
    },
    "required": ["a", "b"],
    "title": "Arguments",
    "type": "object",
}
```

`optimize_schema` reduces this to:

```json
{
    "properties": {
        "a": {"title": "A", "type": "integer"},
        "b": {"title": "B", "type": "integer"},
    },
    "required": ["a"],
    "title": "Arguments",
    "type": "object",
}
```

---

I decided to add a flag, `enable_schema_optimization`, and set it to `False` by default because it further restricts the support distribution and thus might break models finetuned without this setting.