### PR TITLE
Version the Documentation

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - created
 
 permissions:
   contents: write
@@ -14,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -25,7 +30,24 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements-doc.txt
-      - name: Build documentation
+      - run: mkdocs build
+
+      - name: Set up Git
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+
+      - name: Publish Tag as latest
         env:
           GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-        run: mkdocs gh-deploy --force
+        if: github.event_name == 'release'
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          mike set-default --push latest
+
+      - name: Publish main as unstable
+        env:
+          GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
+        if: github.event_name == 'push'
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} unstable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,10 @@ extra:
   analytics:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY
+  version:
+    provider: mike
+    default: latest
+    alias: true
 
 # Extensions
 markdown_extensions:

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,3 +6,4 @@ mkdocs-section-index
 mkdocstrings[python]
 mkdocs-git-committers-plugin-2
 mkdocs-git-revision-date-localized-plugin
+mike


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/999

# Changes

Versions the documentation using `mike`.

Demo: 
- Site: https://lapp0.github.io/outlines/
- Branch: https://github.com/lapp0/outlines/tree/gh-pages

Behavior:
- Doesn't backfill documentation versioning.
- Has drop-down for version history, including all versions starting with the next release
- Version dropdown: "main / unstable", followed by "[latest version number] / stable", followed by all prior versions
- `/` redirects to `/stable`
- **breaks any external links to documentation**
  - e.g. https://outlines-dev.github.io/outlines/reference/json_mode/ is now https://outlines-dev.github.io/outlines/latest/reference/json_mode/

# Set Up

**Must have https://github.com/outlines-dev/outlines/settings/pages set to "deploy from a branch" with branch of `gh-pages`**

**Must cut a release after merging for the following reason:**

- After merging this PR:
  - 404: https://outlines-dev.github.io/outlines/
  - 404: https://outlines-dev.github.io/outlines/latest
  - 200: https://outlines-dev.github.io/outlines/unstable

- After cutting a release
  - 302: https://outlines-dev.github.io/outlines/ -> https://outlines-dev.github.io/outlines/latest
  - 200: https://outlines-dev.github.io/outlines/latest