### PR TITLE
Remove Broken pyairports Package, Replace with airportsdata

### DIFF
--- a/outlines/types/airports.py
+++ b/outlines/types/airports.py
@@ -1,10 +1,11 @@
 """Generate valid airport codes."""
 from enum import Enum
 
-from pyairports.airports import AIRPORT_LIST
+import airportsdata
 
-AIRPORT_IATA_LIST = list(
-    {(airport[3], airport[3]) for airport in AIRPORT_LIST if airport[3] != ""}
-)
+AIRPORT_IATA_LIST = [
+    (v["iata"], v["iata"]) for v in airportsdata.load().values() if v["iata"]
+]
+
 
 IATA = Enum("Airport", AIRPORT_IATA_LIST)  # type:ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
    "datasets",
    "typing_extensions",
    "pycountry",
-   "pyairports",
+   "airportsdata",
 ]
 dynamic = ["version"]
 
@@ -137,7 +137,7 @@ module = [
     "uvicorn.*",
     "fastapi.*",
     "pycountry.*",
-    "pyairports.*",
+    "airportsdata.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Fixes https://github.com/dottxt-ai/outlines/issues/1093

`pyairports` is unmaintained and often breaks `pip install outlines`. It's also out of date.

This PR replaces it with the more recently maintained and working package [airportsdata](https://github.com/mborsetti/airportsdata/)