### PR TITLE
Don't re-use logits processors in SequenceGeneratorAdapter, copy them

### DIFF
--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -1,4 +1,5 @@
 import datetime
+from copy import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
@@ -503,7 +504,7 @@ class SequenceGeneratorAdapter:
         completions = self.model.generate(
             prompts,
             generation_params,
-            self.logits_processor,
+            copy(self.logits_processor),
             self.sampling_params,
             **model_specific_params,
         )
@@ -525,7 +526,7 @@ class SequenceGeneratorAdapter:
         return self.model.stream(
             prompts,
             generation_params,
-            self.logits_processor,
+            copy(self.logits_processor),
             self.sampling_params,
             **model_specific_params,
         )
@@ -556,7 +557,7 @@ class VisionSequenceGeneratorAdapter(SequenceGeneratorAdapter):
             prompts,
             media,
             generation_params,
-            self.logits_processor,
+            copy(self.logits_processor),
             self.sampling_params,
             **model_specific_params,
         )
@@ -581,7 +582,7 @@ class VisionSequenceGeneratorAdapter(SequenceGeneratorAdapter):
             prompts,
             media,
             generation_params,
-            self.logits_processor,
+            copy(self.logits_processor),
             self.sampling_params,
             **model_specific_params,
         )

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -254,6 +254,16 @@ def test_generate_choice(request, model_fixture, sample_choices):
 
 
 @pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
+def test_generate_choice_twice(request, model_fixture, sample_choices):
+    model = request.getfixturevalue(model_fixture)
+    generator = generate.choice(model, sample_choices)
+    res = generator(**get_inputs(model_fixture))
+    assert res in sample_choices
+    res = generator(**get_inputs(model_fixture))
+    assert res in sample_choices
+
+
+@pytest.mark.parametrize("model_fixture", ALL_MODEL_FIXTURES)
 def test_generate_format_bool(request, model_fixture):
     model = request.getfixturevalue(model_fixture)
     generator = generate.format(model, bool)


### PR DESCRIPTION
Fixes https://github.com/dottxt-ai/outlines/issues/1109

# Problem

Logits processors can't be reused across multiple generation runs and must be copied. `SequenceGeneratorAdapter` wasn't respecting this requirement. The result is that in `generator = generate.choice(...)`, the `generator` can only be used once.

During inference, logits processors are called with a sequence of `input_ids + output_ids`. Since structured generation only applies to `output_ids`, we track the length of `input_ids` on the first call and treat subsequent tokens as `output_ids`. However, this approach fails when the `input_ids` sequence changes.

# Solution
`copy` the logits processors for each `SequenceGeneratorAdapter.__call__(...)`, ensuring they can correctly determine the start of `output_ids`.

# Further Work

Logits processors requires more documentation. Especially since vLLM contributors have discussed replacing Outlines logits processors implementation with `import outlines.processors`.