### PR TITLE
Add OpenAI to LogitsGenerator

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -16,4 +16,4 @@ from .transformers import Transformers, TransformerTokenizer, mamba, transformer
 from .transformers_vision import TransformersVision, transformers_vision
 from .vllm import VLLM, vllm
 
-LogitsGenerator = Union[Transformers, LlamaCpp, ExLlamaV2Model, MLXLM, VLLM]
+LogitsGenerator = Union[Transformers, LlamaCpp, OpenAI, ExLlamaV2Model, MLXLM, VLLM]


### PR DESCRIPTION
This is tiny, and I might be wrong in case `OpenAI` (since it's basically an API wrapper) is in fact NOT a `LogitsGenerator`.

But adding it seems logical, and I want it to be in there for my use case (which is that I have a function that creates a model, and with this change I can specify the return type to be `LogitsGenerator`).

- [X] We should be able to understand what the PR does from its title only;
- [X] There is a high-level description of the changes;
- [ ] *If I add a new feature*, there is an [issue][issues] discussing it already;
- [ ] There are links to *all* the relevant issues, discussions and PRs;
- [X] The branch is rebased on the latest `main` commit;
- [X] **Commit messages** follow these [guidelines][git-guidelines];
- [X] One commit per logical change;
- [X] The code respects the current **naming conventions**;
- [X] Docstrings follow the [numpy style guide][docstring-guidelines];
- [X] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
- [ ] There are tests covering the changes;
- [X] The documentation is up-to-date;