### PR TITLE
Fix Broken Docs Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Made with ❤👷️ by the team at [.txt](https://dottxt.co).
 pip install outlines
 ```
 
-First time here? Go to our [setup guide](https://dottxt-ai.github.io/outlines/welcome)
+First time here? Go to our [setup guide](https://dottxt-ai.github.io/outlines/latest/welcome/)
 
 ## Features
 
-- [x] 🤖 [Multiple model integrations](https://dottxt-ai.github.io/outlines/installation): OpenAI, transformers, llama.cpp, exllama2, mamba
+- [x] 🤖 [Multiple model integrations](https://dottxt-ai.github.io/outlines/latest/installation): OpenAI, transformers, llama.cpp, exllama2, mamba
 - [x] 🖍️ Simple and powerful prompting primitives based on the [Jinja templating engine](https://jinja.palletsprojects.com/)
 - [x] 🚄 [Multiple choices](#multiple-choices), [type constraints](#type-constraint) and dynamic stopping
 - [x] ⚡ Fast [regex-structured generation](#efficient-regex-structured-generation)
@@ -35,7 +35,7 @@ First time here? Go to our [setup guide](https://dottxt-ai.github.io/outlines/we
 - [x] 💾 Caching of generations
 - [x] 🗂️ Batch inference
 - [x] 🎲 Sample with the greedy, multinomial and beam search algorithms (and more to come!)
-- [x] 🚀 [Serve with vLLM](https://dottxt-ai.github.io/outlines/reference/serve/vllm), with official Docker image, [`outlinesdev/outlines`](https://hub.docker.com/r/outlinesdev/outlines)!
+- [x] 🚀 [Serve with vLLM](https://dottxt-ai.github.io/outlines/latest/reference/serve/vllm), with official Docker image, [`outlinesdev/outlines`](https://hub.docker.com/r/outlinesdev/outlines)!
 
 
 Outlines  has new releases and features coming every week. Make sure to ⭐ star and 👀 watch this repository, follow [@dottxtai][dottxt-twitter] to stay up to date!
@@ -338,7 +338,7 @@ answer = outlines.generate.text(model)(prompt, max_tokens=100)
 ## Join us
 
 - 💡 **Have an idea?** Come chat with us on [Discord][discord]
-- 🔨 **Want to contribute?** Consult our [contribution guide](https://dottxt-ai.github.io/outlines/community/contribute/).
+- 🔨 **Want to contribute?** Consult our [contribution guide](https://dottxt-ai.github.io/outlines/latest/community/contribute/).
 - 🐞 **Found a bug?** Open an [issue](https://github.com/dottxt-ai/outlines/issues)
 
 
@@ -353,7 +353,7 @@ answer = outlines.generate.text(model)(prompt, max_tokens=100)
 }
 ```
 
-[documentation]: https://dottxt-ai.github.io/outlines/welcome/
+[documentation]: https://dottxt-ai.github.io/outlines/latest/welcome/
 [documentation-badge]: https://img.shields.io/readthedocs/outlines
 [contributors]: https://github.com/dottxt-ai/outlines/graphs/contributors
 [contributors-badge]: https://img.shields.io/github/contributors/dottxt-ai/outlines?style=flat-square&logo=github&logoColor=white&color=ECEFF4

--- a/docs/cookbook/simtom.md
+++ b/docs/cookbook/simtom.md
@@ -17,9 +17,9 @@ SimToM calls an LLM with two consecutive prompts:
 
 To implement SimToM with Outlines, we will need to:
 
-1. Write the prompts with [prompt functions](https://dottxt-ai.github.io/outlines/reference/prompting/).
+1. Write the prompts with [prompt functions](https://dottxt-ai.github.io/outlines/latest/reference/prompting/).
 2. Define the JSON object each prompt will return using Pydantic.
-3. Generate responses with a Mistral model using the [transformers integration](https://dottxt-ai.github.io/outlines/reference/models/transformers/).
+3. Generate responses with a Mistral model using the [transformers integration](https://dottxt-ai.github.io/outlines/latest/reference/models/transformers/).
 
 Let's dive into it!
 

--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -107,7 +107,7 @@ class CFGGuide(Guide):
         """
         warnings.warn(
             "Outlines' public *community-contributed* CFG structured generation is experimental. "
-            "Please review https://dottxt-ai.github.io/outlines/reference/cfg#disclaimer"
+            "Please review https://dottxt-ai.github.io/outlines/latest/reference/generation/cfg#disclaimer"
         )
 
         self.cfg_string = cfg_string

--- a/outlines/models/exllamav2.py
+++ b/outlines/models/exllamav2.py
@@ -302,7 +302,7 @@ def exl2(
         raise ImportError(
             "The `exllamav2`, `transformers` and `torch` libraries needs to be installed in order to use `exllamav2` models. "
             "Please run `pip install transformers torch git+https://github.com/lapp0/exllamav2@sampler-logits-processor` "
-            "Documentation: https://dottxt-ai.github.io/outlines/reference/models/exllamav2/"
+            "Documentation: https://dottxt-ai.github.io/outlines/latest/reference/models/exllamav2/"
         )
     config = ExLlamaV2Config(model_path)
     if max_chunk_size is not None:


### PR DESCRIPTION
Example:
- Broken: https://dottxt-ai.github.io/outlines/reference/prompting/
- Fixed: https://dottxt-ai.github.io/outlines/latest/reference/prompting/

Note: https://dottxt-ai.github.io/outlines/ is valid, as it redirects to `outlines/latest/`