### PR TITLE
Bump outlines-core version to 0.1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
    "typing_extensions",
    "pycountry",
    "airportsdata",
-   "outlines_core==0.1.0",
+   "outlines_core>=0.1.13",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
First version where the wheels are available. Closes #1202. Closes #1198.