### PR TITLE
Compatibility updates for next `outlines-core` release

### DIFF
--- a/benchmarks/bench_json_schema.py
+++ b/benchmarks/bench_json_schema.py
@@ -77,4 +77,4 @@ class JsonSchemaBenchmark:
     @cache_disabled()
     def time_json_schema_to_fsm(self, schema_name):
         regex = build_regex_from_schema(self.schema)
-        RegexGuide(regex, self.tokenizer)
+        RegexGuide.from_regex(regex, self.tokenizer)

--- a/benchmarks/bench_regex_guide.py
+++ b/benchmarks/bench_regex_guide.py
@@ -25,7 +25,7 @@ class RegexGuideBenchmark:
 
     @cache_disabled()
     def time_regex_to_guide(self, pattern_name):
-        RegexGuide(self.pattern, self.tokenizer)
+        RegexGuide.from_regex(self.pattern, self.tokenizer)
 
 
 class MemoryRegexGuideBenchmark:
@@ -37,4 +37,4 @@ class MemoryRegexGuideBenchmark:
 
     @cache_disabled()
     def peakmem_regex_to_guide(self, pattern_name):
-        RegexGuide(self.pattern, self.tokenizer)
+        RegexGuide.from_regex(self.pattern, self.tokenizer)

--- a/outlines/fsm/guide.py
+++ b/outlines/fsm/guide.py
@@ -74,8 +74,8 @@ class StopAtEOSGuide(Guide):
 
 
 @cache()
-def create_states_mapping(regex_string, tokenizer):
-    return uncached_create_states_mapping(regex_string, tokenizer)
+def cached_create_states_mapping(regex_string, tokenizer, *args, **kwargs):
+    return uncached_create_states_mapping(regex_string, tokenizer, *args, **kwargs)
 
 
 class RegexGuide(CoreRegexGuide):
@@ -84,15 +84,19 @@ class RegexGuide(CoreRegexGuide):
     CoreRegexGuide with outlines cache
     """
 
-    def __init__(self, regex_string: str, tokenizer: "Tokenizer"):
-        (
-            self.states_to_token_maps,
-            self.empty_token_ids,
-            fsm_finals,
-        ) = create_states_mapping(regex_string, tokenizer)
-        self.eos_token_id = tokenizer.eos_token_id
-        self.final_states = fsm_finals | {-1}
-        self._cache_state_to_token_tensor()
+    @classmethod
+    def from_regex(
+        cls,
+        regex_string: str,
+        tokenizer,
+        **kwargs,
+    ):
+        return super().from_regex(
+            regex_string,
+            tokenizer,
+            _create_states_mapping=cached_create_states_mapping,
+            **kwargs,
+        )
 
 
 CFGState = collections.namedtuple("CFGState", ["parser_state", "prev_token"])

--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -149,7 +149,7 @@ class RegexLogitsProcessor(GuideLogitsProcessor):
         tokenizer
             An Outlines tokenizer
         """
-        guide = RegexGuide(regex_string, tokenizer)
+        guide = RegexGuide.from_regex(regex_string, tokenizer)
         super().__init__(tokenizer=tokenizer, guide=guide)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
    "typing_extensions",
    "pycountry",
    "airportsdata",
-   "outlines_core==0.1.0",
+   "torch",
+   "outlines_core==0.1.14",
 ]
 dynamic = ["version"]
 
@@ -61,7 +62,6 @@ test = [
     "huggingface_hub",
     "openai>=1.0.0",
     "vllm; sys_platform != 'darwin'",
-    "torch",
     "transformers",
     "pillow",
     "exllamav2",

--- a/tests/fsm/test_guide.py
+++ b/tests/fsm/test_guide.py
@@ -43,7 +43,7 @@ def test_regex_vocabulary_error():
     regex_str = "[1-9]"
 
     with pytest.raises(ValueError, match="The vocabulary"):
-        RegexGuide(regex_str, MockTokenizer())
+        RegexGuide.from_regex(regex_str, MockTokenizer())
 
 
 def test_regex():
@@ -57,7 +57,7 @@ def test_regex():
 
     regex_str = "[1-9]"
     tokenizer = MockTokenizer()
-    fsm = RegexGuide(regex_str, tokenizer)
+    fsm = RegexGuide.from_regex(regex_str, tokenizer)
 
     assert fsm.states_to_token_maps == {0: {1: 1}}
 
@@ -98,7 +98,7 @@ def test_regex_multi_byte_llama_like():
 
     regex_str = "[😁-😎]"
     tokenizer = MockTokenizer()
-    fsm = RegexGuide(regex_str, tokenizer)
+    fsm = RegexGuide.from_regex(regex_str, tokenizer)
 
     assert fsm.states_to_token_maps == {
         0: {5: 1, 4: 2},
@@ -145,7 +145,7 @@ def test_regex_multi_byte_gpt2_like():
 
     regex_str = " [😁-😎]"
     tokenizer = MockTokenizer()
-    fsm = RegexGuide(regex_str, tokenizer)
+    fsm = RegexGuide.from_regex(regex_str, tokenizer)
 
     assert fsm.states_to_token_maps == {
         0: {5: 1, 10: 2},
@@ -180,7 +180,7 @@ def test_regex_final_state():
 
     regex_str = r"`\n(\.\n)?`\n"
     tokenizer = MockTokenizer()
-    fsm = RegexGuide(regex_str, tokenizer)
+    fsm = RegexGuide.from_regex(regex_str, tokenizer)
 
     state = fsm.get_next_state(state=4, token_id=103)
     assert state == 5

--- a/tests/generate/test_integration_llamacpp.py
+++ b/tests/generate/test_integration_llamacpp.py
@@ -278,7 +278,7 @@ def test_RegexGuide_caching(model, temp_cache_dir):
     import llama_cpp
 
     import outlines.caching
-    from outlines.fsm.guide import create_states_mapping
+    from outlines.fsm.guide import cached_create_states_mapping
 
     assert outlines.caching._caching_enabled
 
@@ -291,7 +291,7 @@ def test_RegexGuide_caching(model, temp_cache_dir):
     _ = cache.stats(enable=True)
     assert cache.statistics
 
-    assert create_states_mapping.__memory__ is cache
+    assert cached_create_states_mapping.__memory__ is cache
 
     generator = generate.regex(model, regex, sampler=samplers.greedy())
     assert cache.stats() == (0, 1)

--- a/tests/generate/test_integration_transformers.py
+++ b/tests/generate/test_integration_transformers.py
@@ -494,7 +494,7 @@ def test_transformers_use_existing_model_and_tokenizer():
 
 def test_RegexGuide_caching(temp_cache_dir):
     import outlines.caching
-    from outlines.fsm.guide import create_states_mapping
+    from outlines.fsm.guide import cached_create_states_mapping
 
     assert outlines.caching._caching_enabled
 
@@ -507,7 +507,7 @@ def test_RegexGuide_caching(temp_cache_dir):
     _ = cache.stats(enable=True)
     assert cache.statistics
 
-    assert create_states_mapping.__memory__ is cache
+    assert cached_create_states_mapping.__memory__ is cache
 
     model = models.transformers(
         "hf-internal-testing/tiny-random-XLMRobertaXLForCausalLM", device="cpu"


### PR DESCRIPTION
Necessary changes to use `outlines-core==0.1.14`

# Changes
- `fsm_union`, `walk_fsm`, and `get_sub_fsms_from_seq` were missing from `outlines/fsm/parsing.py`, breaking CFG. We include it once again
- pin to `outlines-core==0.1.14`, which includes wheels and removes the requirement for a rust compiler to install.
  - Fixes https://github.com/dottxt-ai/outlines/issues/1198
  - Fixes https://github.com/dottxt-ai/outlines/issues/1202
- Update `RegexGuide` to conform to to `outlines-core`
- make `torch` a default requirements
  - Fixes https://github.com/dottxt-ai/outlines/issues/1197