### PR TITLE
fix: Make `convert_token_to_string` pickleable

### DIFF
--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -208,20 +208,35 @@ def adapt_tokenizer(tokenizer: "PreTrainedTokenizerBase") -> "PreTrainedTokenize
 
     tokenizer.vocabulary = tokenizer.get_vocab()
     tokenizer.special_tokens = set(tokenizer.all_special_tokens)
-
-    def convert_token_to_string(token: Union[str, bytes]) -> str:
-        string = tokenizer.convert_tokens_to_string([token])
-
-        # A hack to handle missing spaces to HF's Llama tokenizers
-        if (
-            type(token) is str
-            and token.startswith(SPIECE_UNDERLINE)
-            or token == "<0x20>"
-        ):
-            return " " + string
-
-        return string
-
     tokenizer.convert_token_to_string = convert_token_to_string
-
     return tokenizer
+
+
+def convert_token_to_string(
+    token: Union[str, bytes], tokenizer: PreTrainedTokenizerBase
+) -> str:
+    """Convert a token to a string.
+
+    Parameters
+    ----------
+    token
+        The token to convert.
+    tokenizer
+        The tokenizer of the model.
+
+    Returns
+    -------
+    str
+        The string representation of the token.
+    """
+    string = tokenizer.convert_tokens_to_string([token])
+
+    # A hack to handle missing spaces to HF's Llama tokenizers
+    if (
+        type(token) is str
+        and token.startswith(SPIECE_UNDERLINE)
+        or token == "<0x20>"
+    ):
+        return " " + string
+
+    return string

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -232,11 +232,7 @@ def convert_token_to_string(
     string = tokenizer.convert_tokens_to_string([token])
 
     # A hack to handle missing spaces to HF's Llama tokenizers
-    if (
-        type(token) is str
-        and token.startswith(SPIECE_UNDERLINE)
-        or token == "<0x20>"
-    ):
+    if type(token) is str and token.startswith(SPIECE_UNDERLINE) or token == "<0x20>":
         return " " + string
 
     return string

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -1,7 +1,7 @@
 """Tests for the `vllm` module."""
 
 import pytest
-from transformers import AutoTokenizer, SPIECE_UNDERLINE
+from transformers import SPIECE_UNDERLINE, AutoTokenizer
 
 from outlines.models.vllm import adapt_tokenizer, convert_token_to_string
 

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -1,0 +1,29 @@
+"""Tests for the `vllm` module."""
+
+from outlines.models.vllm import adapt_tokenizer, convert_token_to_string
+from transformers import AutoTokenizer, SPIECE_UNDERLINE
+import pytest
+
+TEST_MODEL = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+
+
+def test_adapt_tokenizer():
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL, padding_side="left")
+    adapted_tokenizer = adapt_tokenizer(tokenizer=tokenizer)
+    assert hasattr(adapted_tokenizer, "vocabulary")
+    assert hasattr(adapted_tokenizer, "special_tokens")
+    assert adapted_tokenizer.convert_token_to_string == convert_token_to_string
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        ("baz", "baz"),
+        ("<0x20>", " <0x20>"),
+        (SPIECE_UNDERLINE, f" {SPIECE_UNDERLINE}"),
+    ],
+)
+def test_convert_token_to_string(token, expected):
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL, padding_side="left")
+    output = convert_token_to_string(token=token, tokenizer=tokenizer)
+    assert output == expected

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -1,8 +1,9 @@
 """Tests for the `vllm` module."""
 
-from outlines.models.vllm import adapt_tokenizer, convert_token_to_string
-from transformers import AutoTokenizer, SPIECE_UNDERLINE
 import pytest
+from transformers import AutoTokenizer, SPIECE_UNDERLINE
+
+from outlines.models.vllm import adapt_tokenizer, convert_token_to_string
 
 TEST_MODEL = "hf-internal-testing/tiny-random-GPTJForCausalLM"
 


### PR DESCRIPTION
This moves the `convert_token_to_string` helper function out as an independent function, to make it pickleable.

This is causing issues when storing logits processors in a class that needs to be pickleable.