### PR TITLE
Introducing Outlines Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Contributors][contributors-badge]][contributors]
 [![Downloads][downloads-badge]][pypistats]
 [![Discord][discord-badge]][discord]
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Outlines%20Guru-006BFF)](https://gurubase.io/g/outlines)
 
 
 *Robust (structured) text generation.*


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Outlines Guru](https://gurubase.io/g/outlines) to Gurubase. Outlines Guru uses the data from this repo and data from the [docs](https://dottxt-ai.github.io/outlines/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Outlines Guru", which highlights that Outlines now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Outlines Guru in Gurubase, just let me know that's totally fine.
