### PR TITLE
Add compatibility for numpy 2 while preserving numpy 1 compatibility

### DIFF
--- a/outlines/base.py
+++ b/outlines/base.py
@@ -5,12 +5,23 @@ import inspect
 from typing import Callable, Optional
 
 import numpy as np
-from numpy.lib.function_base import (
-    _calculate_shapes,
-    _parse_gufunc_signature,
-    _parse_input_dimensions,
-    _update_dim_sizes,
-)
+
+# Import required functions based on NumPy version
+np_major_version = int(np.__version__.split(".")[0])
+if np_major_version >= 2:
+    from numpy.lib._function_base_impl import (
+        _calculate_shapes,
+        _parse_gufunc_signature,
+        _parse_input_dimensions,
+        _update_dim_sizes,
+    )
+else:
+    from numpy.lib.function_base import (
+        _calculate_shapes,
+        _parse_gufunc_signature,
+        _parse_input_dimensions,
+        _update_dim_sizes,
+    )
 
 # Allow nested loops for running in notebook. We don't enable it globally as it
 # may interfere with other libraries that use asyncio.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
    "jinja2",
    "lark",
    "nest_asyncio",
-   "numpy<2.0.0",
+   "numpy",
    "cloudpickle",
    "diskcache",
    "pydantic>=2.0",


### PR DESCRIPTION
Check the numpy major version number before deciding which file to import methods from.

I have not benchmarked numpy 1 vs numpy 2 performance for outlines, but I have verified that outlines works as intended when using numpy 2 for the examples in the README.

Closes https://github.com/dottxt-ai/outlines/issues/1104
