### PR TITLE
Add `transformers` to required deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
    "airportsdata",
    "torch",
    "outlines_core==0.1.17",
+   "transformers",
 ]
 dynamic = ["version"]
 
@@ -62,7 +63,6 @@ test = [
     "huggingface_hub",
     "openai>=1.0.0",
     "vllm; sys_platform != 'darwin'",
-    "transformers",
     "pillow",
     "exllamav2",
 ]


### PR DESCRIPTION
This resolves #1263, which I also ran into.

**Slightly unrelated:** It seems like also `numpy` should be pinned to `< 2.0` to avoid an error upon importing `ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`. I can open a new issue for this.