### PR TITLE
Fix GuideLogitsProcessor for MPS device

### DIFF
--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -108,7 +108,7 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
         batch_indices = []
         for i, guide_state in enumerate(sequence_states):
             allowed_tokens = self.guide.get_next_instruction(guide_state).tokens.to(
-                mask.device, non_blocking=True
+                mask.device
             )
             allowed_tokens_batch.append(allowed_tokens)
             batch_indices.append(


### PR DESCRIPTION
While debugging #1282, I found the the issue to be caused by `non_blocking=True` on a Mac with an MPS device.

The usage of `non_blocking=True` is only safe for CPU->GPU, as far as I understand from [this guide](https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html#other-copy-directions-gpu-cpu-cpu-mps).
For other directions, especially CPU->MPS in my case, this results in a all-zero vector instead of the real token ids which generates wrong tokens and results in errors like described in #1282.
I also tried to use `torch.mps.synchronize()`, but it doesn't help.

I'm haven't benchmarked the difference in speed, but I suspect it to be neglectable because the created vector is accessed [directly afterwards](https://github.com/dottxt-ai/outlines/blob/36f1bf27a80f5877b88a915749341664cef4a1ab/outlines/processors/structured.py#L115).

Fixes #1282