### PR TITLE
Filter out input ids not being used in inference. Fixes issue #1294

### DIFF
--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -23,6 +23,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import math
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
@@ -110,7 +111,9 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
             allowed_tokens = self.guide.get_next_instruction(guide_state).tokens.to(
                 mask.device, non_blocking=True
             )
-            allowed_tokens = allowed_tokens[allowed_tokens < mask.shape[-1]] # filter out input ids exceeding the mask length
+            allowed_tokens = allowed_tokens[
+                allowed_tokens < mask.shape[-1]
+            ]  # filter out input ids exceeding the mask length
             allowed_tokens_batch.append(allowed_tokens)
             batch_indices.append(
                 torch.full_like(allowed_tokens, i)

--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -110,6 +110,7 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
             allowed_tokens = self.guide.get_next_instruction(guide_state).tokens.to(
                 mask.device, non_blocking=True
             )
+            allowed_tokens = allowed_tokens[allowed_tokens < mask.shape[-1]] # filter out input ids exceeding the mask length
             allowed_tokens_batch.append(allowed_tokens)
             batch_indices.append(
                 torch.full_like(allowed_tokens, i)


### PR DESCRIPTION
This pull request resolves the below error which arises when using outlines with Llama-3.2-11B-Vision model: 

> IndexError: index 128256 is out of bounds for dimension 1 with size 128256

which arises because the Llama vision processor includes the image token (id 128256) which is not used during inference but this gets included in the `allowed_tokens` tensor while the logits don't have any value for this index. Fixes issue #1294