### PR TITLE
Implement stop_at for mlxlm models

### DIFF
--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -52,6 +52,18 @@ def test_mlxlm_generate():
     assert isinstance(output, str)
     assert len(output) > 0
 
+@pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
+def test_mlxlm_generate_with_stop_at():
+    from outlines.generate.api import GenerationParameters, SamplingParameters
+
+    model  = mlxlm(TEST_MODEL)
+    prompt = "Write sentence and end with \"stop\":"
+
+    gen_params      = GenerationParameters(max_tokens=50, stop_at="stop", seed=None)
+    sampling_params = SamplingParameters(sampler="greedy")
+
+    output = model.generate(prompt, gen_params, None, sampling_params)
+    assert "stop" in output
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
 def test_mlxlm_stream():


### PR DESCRIPTION
I like using outlines because I can have the same code on my local dev machine (Mac) as well as the multi-gpu (transformers+CUDA). One discrepancy I'm running into is that the mlxlm backend does not support the stop_at parameter.

This PR implements a naive version of the extra stopping criterion.