### PR TITLE
Bump outlines-core version to 0.1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
    "pycountry",
    "airportsdata",
    "torch",
-   "outlines_core==0.1.25",
+   "outlines_core==0.1.26",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Include the outlines-core fix (https://github.com/dottxt-ai/outlines-core/pull/123) to this issue: https://github.com/dottxt-ai/outlines-core/issues/122.

Currently, `pip install outlines==0.1.9` is causing vLLM's ARM CPU container to fail to build.