### PR TITLE
Add non-docstring alternative for prompts

### DIFF
--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -115,7 +115,9 @@ def prompt(fn: Callable) -> Prompt:
     template = cast(str, potential_template)
     signature = inspect.signature(fn)
 
-    return Prompt(template, signature)
+    prompt_instance = Prompt(template, signature)
+    prompt_instance.__doc__ = fn.__doc__
+    return prompt_instance
 
 
 def render(template: str, **values: Optional[Dict[str, Any]]) -> str:

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -116,7 +116,6 @@ def prompt(fn: Callable) -> Prompt:
     signature = inspect.signature(fn)
 
     prompt_instance = Prompt(template, signature)
-    prompt_instance.__doc__ = fn.__doc__
     return prompt_instance
 
 

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -51,7 +51,7 @@ def _template_variable_assigned(fn: Callable) -> Optional[str]:
         and instruction_set[2].argrepr == "_"
     ):
         return instruction_set[1].argval
-    elif tuple(
+    elif any(
         instr
         for instr in instruction_set
         if instr.opname == "STORE_FAST" and instr.argrepr == "_"

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -115,8 +115,7 @@ def prompt(fn: Callable) -> Prompt:
     template = cast(str, potential_template)
     signature = inspect.signature(fn)
 
-    prompt_instance = Prompt(template, signature)
-    return prompt_instance
+    return Prompt(template, signature)
 
 
 def render(template: str, **values: Optional[Dict[str, Any]]) -> str:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -148,6 +148,30 @@ def test_prompt_kwargs():
     assert p == "test and test"
 
 
+def test_prompt_template_keyword():
+    @outlines.prompt
+    def test_tpl_keyword(variable):
+        _ = """{{variable}} test"""
+
+    assert test_tpl_keyword.template == "{{variable}} test"
+    assert test_tpl_keyword.parameters == ["variable"]
+
+    @outlines.prompt
+    def test_tpl_keyword_single_quotes(variable):
+        _ = "{{variable}} test"
+
+    assert test_tpl_keyword_single_quotes.template == "{{variable}} test"
+    assert test_tpl_keyword_single_quotes.parameters == ["variable"]
+
+
+def test_prompt_bad_template_keyword():
+    with pytest.raises(ValueError, match="_"):
+
+        @outlines.prompt
+        def test_tpl_keyword(variable):
+            _ = f"{'test'}"
+
+
 def test_no_prompt():
     with pytest.raises(TypeError, match="template"):
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -163,13 +163,6 @@ def test_prompt_template_keyword():
     assert test_tpl_keyword_single_quotes.template == "{{variable}} test"
     assert test_tpl_keyword_single_quotes.parameters == ["variable"]
 
-    @outlines.prompt
-    def test_tpl_keyword_docstring(variable):
-        """docstring"""
-        _ = "{{variable}} test"
-
-    assert test_tpl_keyword_docstring.__doc__ == "docstring"
-
 
 def test_prompt_bad_template_keyword():
     with pytest.raises(ValueError, match="_"):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -163,6 +163,13 @@ def test_prompt_template_keyword():
     assert test_tpl_keyword_single_quotes.template == "{{variable}} test"
     assert test_tpl_keyword_single_quotes.parameters == ["variable"]
 
+    @outlines.prompt
+    def test_tpl_keyword_docstring(variable):
+        """docstring"""
+        _ = "{{variable}} test"
+
+    assert test_tpl_keyword_docstring.__doc__ == "docstring"
+
 
 def test_prompt_bad_template_keyword():
     with pytest.raises(ValueError, match="_"):


### PR DESCRIPTION
Not sure if there's any appetite for this but I figured after diving into it I might as well float it out there.

This PR adds a way to define a prompt that does not exclude the possibility of adding a docstring.  It seems reasonable enough to assume that users of the library might want to provide docstrings for their arguments to the prompt that is not itself a part of the prompt.

```python
@outlines.prompt
def my_complicated_prompt(complicated_argument: str):
  """
  This is a prompt that utilized this cool technique you can read about here:
  https://some.website
  
  Parameters
  ----------
  complicated_argument : 
      this argument will help the model to do x, y, z and should fit within these parameters
      for maximum effectiveness
  """
  
  _ = "The actual prompt is here: {{complicated_argument}}"
```

In addition, making special use of a dunder attribute seems like it could be good to avoid (granted that the suggested parsing of bytecode doesn't seem much more agreeable).

I considered another name for the variable like `TEMPLATE` but was stopped in my tracks by flake8 who understandably gave me an `F841` unused variable warning.  Obviously not something you'd want to pass down to library consumers so `_` it is.

Worth noting this doesn't actually fix automatic doc generation like with `pydoc` because that looks at the after-the-prompt-wrapper instance of the `Prompt` class and gives less than helpful information.