### PR TITLE
Move generation of sampling params

### DIFF
--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 from outlines.generate.generator import sequence_generator
-from outlines.samplers import BeamSearchSampler, GreedySampler, MultinomialSampler
 
 if TYPE_CHECKING:
     import torch
@@ -428,22 +427,7 @@ class SequenceGeneratorAdapter:
         self.model = model
         self.logits_processor = logits_processor
 
-        if isinstance(sampler, MultinomialSampler):
-            self.sampling_params = SamplingParameters(
-                "multinomial",
-                sampler.samples,
-                sampler.top_p,
-                sampler.top_k,
-                sampler.temperature,
-            )
-        elif isinstance(sampler, GreedySampler):
-            self.sampling_params = SamplingParameters(
-                "greedy", sampler.samples, None, None, 0.0
-            )
-        elif isinstance(sampler, BeamSearchSampler):
-            self.sampling_params = SamplingParameters(
-                "beam_search", sampler.samples, None, None, 1.0
-            )
+        self.sampling_params = sampler.samplig_params
 
     def prepare_generation_parameters(
         self,

--- a/outlines/generate/api.py
+++ b/outlines/generate/api.py
@@ -352,11 +352,13 @@ class SequenceGenerator:
                     ]
 
                     generated_sequences = [
-                        self.format_sequence(
-                            self.strip_stop_sequences(sequence, stop_sequences)
+                        (
+                            self.format_sequence(
+                                self.strip_stop_sequences(sequence, stop_sequences)
+                            )
+                            if stop
+                            else sequence
                         )
-                        if stop
-                        else sequence
                         for sequence, stop in zip(
                             generated_sequences, is_stop_at_reached
                         )
@@ -427,7 +429,7 @@ class SequenceGeneratorAdapter:
         self.model = model
         self.logits_processor = logits_processor
 
-        self.sampling_params = sampler.samplig_params
+        self.sampling_params = sampler.sampling_params
 
     def prepare_generation_parameters(
         self,

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -47,6 +47,13 @@ def test_greedy():
     assert ancestors.equal(torch.tensor([0, 1]))
     assert weights.equal(torch.tensor([logprobs[0, 0], logprobs[1, 2]]))
 
+    params = sampler.sampling_params
+    assert params.sampler == "greedy"
+    assert params.num_samples == 1
+    assert params.top_p is None
+    assert params.top_k is None
+    assert params.temperature == 0.0
+
 
 def test_multinomial():
     rng = torch.Generator()
@@ -71,6 +78,14 @@ def test_multinomial():
     assert next_token_ids.equal(torch.tensor([[0], [2]]))
     assert ancestors.equal(torch.tensor([0, 1]))
     assert weights.equal(torch.tensor([logprobs[0, 0], logprobs[1, 2]]))
+
+    sampler = MultinomialSampler(samples=5, top_k=10, top_p=0.9, temperature=0.8)
+    params = sampler.sampling_params
+    assert params.sampler == "multinomial"
+    assert params.num_samples == 5
+    assert params.top_p == 0.9
+    assert params.top_k == 10
+    assert params.temperature == 0.8
 
 
 def test_multinomial_init():
@@ -252,3 +267,11 @@ def test_beam_search():
             ]
         )
     )
+
+    sampler = BeamSearchSampler(beams=3)
+    params = sampler.sampling_params
+    assert params.sampler == "beam_search"
+    assert params.num_samples == 3
+    assert params.top_p is None
+    assert params.top_k is None
+    assert params.temperature == 1.0


### PR DESCRIPTION
This PR addresses #1335 
I have kept the `SamplingParameters` in `outlines/generate/api.py`  cause its imported at many places and may break examples ig. 
Would you want to change that @dgerlanc ??
Otherwise if this looks good, I can make docs changes if needd, lmk.