### PR TITLE
Fix image link in receipt-digitization example

### DIFF
--- a/docs/cookbook/receipt-digitization.md
+++ b/docs/cookbook/receipt-digitization.md
@@ -117,7 +117,7 @@ Here's what the image looks like:
 
 ```python
 # Path to the image
-image_path = "https://dottxt-ai.github.io/outlines/main/cookbook/images/trader-joes-receipt.png"
+image_path = "https://raw.githubusercontent.com/dottxt-ai/outlines/refs/heads/main/docs/cookbook/images/trader-joes-receipt.jpg"
 
 # Download the image
 response = requests.get(image_path)


### PR DESCRIPTION
The current link points to a HTML instead of a PNG, so after it's downloaded via requests.get, PIL isn't able to recognize the format and rightly so.