### PR TITLE
Set docs `docstring_style`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ plugins:
       handlers:
         python:
           options:
+            docstring_style: numpy
             show_submodules: true
   - search
   - section-index


### PR DESCRIPTION
Hi, Thank you for this great library!

It seems that the docstrings are not rendered correctly in the docs. I think we should explicitly set the `docstring_style` because [it defaults to `"google"`](https://mkdocstrings.github.io/python/usage/configuration/docstrings/#docstring_style) but outlines is using numpy.

Before:
![Screenshot 2024-12-16 at 23 00 26](https://github.com/user-attachments/assets/c752ee3d-519e-4098-b943-3aab43c8af25)
After:
![Screenshot 2024-12-16 at 23 00 41](https://github.com/user-attachments/assets/5b5f524b-6921-4dbe-994d-72c079e677bc)


There seem to be other issues in the docstrings:
- for example [`Properties`](https://github.com/dottxt-ai/outlines/blob/main/outlines/models/openai.py#L23) should be [`Attributes`](https://numpydoc.readthedocs.io/en/latest/format.html#parameters)
- only openai and transformers models are present in the [api reference](https://github.com/dottxt-ai/outlines/blob/main/docs/api/models.md) 

I'm happy to make followup PRs for those.

Please let me know if I missed something, I couldn't find related issues/PRs.