### PR TITLE
Skip `vllm`-related tests on non-linux platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
     "huggingface_hub",
     "openai>=1.0.0",
     "datasets",
-    "vllm; sys_platform != 'darwin'",
+    "vllm; sys_platform == 'linux'",
     "transformers",
     "pillow",
     "exllamav2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    if sys.platform != "linux":
+        skip_vllm = pytest.mark.skip(reason="vLLM models can only be run on Linux.")
+        for item in items:
+            if "test_integration_vllm" in item.nodeid:
+                item.add_marker(skip_vllm)
+                print(
+                    f"WARNING: {item.nodeid} is skipped because vLLM only supports Linux platform (including WSL)."
+                )

--- a/tests/generate/test_integration_vllm.py
+++ b/tests/generate/test_integration_vllm.py
@@ -4,7 +4,11 @@ import re
 import pytest
 import torch
 from pydantic import BaseModel, constr
-from vllm.sampling_params import SamplingParams
+
+try:
+    from vllm.sampling_params import SamplingParams
+except ImportError:
+    pass
 
 import outlines.generate as generate
 import outlines.grammars as grammars


### PR DESCRIPTION
Fix #1356