### PR TITLE
Fix `json_schema` imports in cot example

### DIFF
--- a/docs/cookbook/chain_of_thought.md
+++ b/docs/cookbook/chain_of_thought.md
@@ -80,8 +80,8 @@ json_schema = Reasoning.model_json_schema()
 We could generate a response using the json schema but for a change we will use the regex:
 
 ```python
-from outlines.integrations.utils import convert_json_schema_to_str
-from outlines.fsm.json_schema import build_regex_from_schema
+from outlines.fsm.json_schema import convert_json_schema_to_str
+from outlines_core.fsm.json_schema import build_regex_from_schema
 
 schema_str = convert_json_schema_to_str(json_schema=json_schema)
 regex_str = build_regex_from_schema(schema_str)


### PR DESCRIPTION
- Replace `outlines.integrations` import with import from `outlines.fsm.json_schema` (#1061) 
- Fix `build_regex_from_schema` to import from `outlines_core` instead of `outlines` (#1311)