### PR TITLE
Fix `vllm`-related pytest warning (that was spaming user)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,13 @@ import pytest
 
 def pytest_collection_modifyitems(config, items):
     if sys.platform != "linux":
+        if not config.option.keyword or (
+            config.option.keyword and "test_integration_vllm" in config.option.keyword
+        ):
+            print(
+                "WARNING: test_integration_vllm tests are skipped because vLLM only supports Linux platform (including WSL)."
+            )
         skip_vllm = pytest.mark.skip(reason="vLLM models can only be run on Linux.")
         for item in items:
             if "test_integration_vllm" in item.nodeid:
                 item.add_marker(skip_vllm)
-                print(
-                    f"WARNING: {item.nodeid} is skipped because vLLM only supports Linux platform (including WSL)."
-                )


### PR DESCRIPTION
Before this commit, when you ran `pytest -k specific_test`, it spawned dozens of the same skipped warnings message on stdout... IMHO, that was not ideal ^^

Bug introduced in d32dfde3ae7eac71f57af96d5141975ef9322b12, see previous PR https://github.com/dottxt-ai/outlines/pull/1357