### PR TITLE
[docs] Fix `transformers_vision` multiple Images example

### DIFF
--- a/docs/reference/models/transformers_vision.md
+++ b/docs/reference/models/transformers_vision.md
@@ -2,7 +2,7 @@
 
 Outlines allows seamless use of [vision models](https://huggingface.co/learn/computer-vision-course/en/unit4/multimodal-models/tasks-models-part1).
 
-`outlines.models.transformers_vision` has shares interfaces with, and is based on [outlines.models.transformers](./transformers.md).
+`outlines.models.transformers_vision` shares interfaces with, and is based on [outlines.models.transformers](./transformers.md).
 
 Tasks supported include
 
@@ -62,7 +62,7 @@ image_urls = [
 ]
 description_generator = outlines.generate.text(model)
 description_generator(
-    "<image><image><image>What shapes are present?",
+    "<image><image>What shapes are present?",
     list(map(img_from_url, image_urls)),
 )
 ```
@@ -110,6 +110,6 @@ image_data_generator(
 
 ## Resources
 
-### Chosing a model
+### Choosing a model
 - https://mmbench.opencompass.org.cn/leaderboard
 - https://huggingface.co/spaces/WildVision/vision-arena


### PR DESCRIPTION
`transformers` maintainer here 👋 

Was trying out your `transformers_vision` example, and ran into a bug in the example. In a nutshell, the original demo prompted the model with 3 images, but only two were being passed.

<details>
  <summary>Stand-alone script for reproduction, based on the example:</summary>

```py
import outlines
from transformers import LlavaNextForConditionalGeneration
import torch

model = outlines.models.transformers_vision(
    "llava-hf/llava-v1.6-mistral-7b-hf",
    model_class=LlavaNextForConditionalGeneration,
)


from PIL import Image
from io import BytesIO
from urllib.request import urlopen

def img_from_url(url):
    img_byte_stream = BytesIO(urlopen(url).read())
    return Image.open(img_byte_stream).convert("RGB")


description_generator = outlines.generate.text(model)
foo = description_generator(
    "<image> detailed description:",
    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg")]
)
print(foo)


image_urls = [
    "https://cdn1.byjus.com/wp-content/uploads/2020/08/ShapeArtboard-1-copy-3.png",  # triangle
    "https://cdn1.byjus.com/wp-content/uploads/2020/08/ShapeArtboard-1-copy-11.png",  # hexagon
]
description_generator = outlines.generate.text(model)
foo = description_generator(
    "<image><image>What shapes are present?",
    list(map(img_from_url, image_urls)),
)
print(foo)


pattern = "Mercury|Venus|Earth|Mars|Saturn|Jupiter|Neptune|Uranus|Pluto"
planet_generator = outlines.generate.regex(model, pattern)

foo = planet_generator(
    "What planet is this: <image>",
    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/e/e3/Saturn_from_Cassini_Orbiter_%282004-10-06%29.jpg")]
)
print(foo)


from pydantic import BaseModel
from typing import List, Optional

class ImageData(BaseModel):
    caption: str
    tags_list: List[str]
    object_list: List[str]
    is_photo: bool

image_data_generator = outlines.generate.json(model, ImageData)

foo = image_data_generator(
    "<image> detailed JSON metadata:",
    [img_from_url("https://upload.wikimedia.org/wikipedia/commons/9/98/Aldrin_Apollo_11_original.jpg")]
)
print(foo)
```
</details>


<details>
  <summary>Original traceback error:</summary>

```
Traceback (most recent call last):
  File "/home/joao/transformers/../joao_scripts/dbg.py", line 38, in <module>                                                                             foo = description_generator(                                                                                                                        File "/home/joao/venvs/hf/lib/python3.10/site-packages/outlines/generate/api.py", line 556, in __call__
    completions = self.model.generate(
  File "/home/joao/venvs/hf/lib/python3.10/site-packages/outlines/models/transformers_vision.py", line 46, in generate
    inputs = self.processor(                                                                                                                            File "/home/joao/transformers/src/transformers/models/llava_next/processing_llava_next.py", line 165, in __call__
    image_size = next(image_sizes)
StopIteration
```
</details>

The other fixes are typos that Grammarly detected :)