### PR TITLE
add filters to prompt function

### DIFF
--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Type, cast
+from typing import Any, Callable, List, Dict, Optional, Type, cast, Union
 
 import jinja2
 import pydantic
@@ -40,7 +40,7 @@ class Prompt:
             return self.template.render(**kwargs)
 
     @classmethod
-    def from_str(cls, content: str):
+    def from_str(cls, content: str, **filters: Dict[str, Callable]):
         """
         Create an instance of the class from a string.
 
@@ -53,10 +53,10 @@ class Prompt:
         -------
         An instance of the class with the provided content as a template.
         """
-        return cls(cls._template_from_str(content), None)
+        return cls(cls._template_from_str(content, **filters), None)
 
     @classmethod
-    def from_file(cls, path: Path):
+    def from_file(cls, path: Path, **filters: Dict[str, Callable]):
         """
         Create a Prompt instance from a file containing a Jinja template.
 
@@ -75,10 +75,10 @@ class Prompt:
         """
         # We don't use a `Signature` here because it seems not feasible to infer one from a Jinja2 environment that is
         # split across multiple files (since e.g. we support features like Jinja2 includes and template inheritance)
-        return cls(cls._template_from_file(path), None)
+        return cls(cls._template_from_file(path, **filters), None)
 
     @classmethod
-    def _template_from_str(_, content: str) -> jinja2.Template:
+    def _template_from_str(_, content: str, **filters: Dict[str, Callable]) -> jinja2.Template:
         # Dedent, and remove extra linebreak
         cleaned_template = inspect.cleandoc(content)
 
@@ -106,10 +106,13 @@ class Prompt:
         env.filters["schema"] = get_schema
         env.filters["args"] = get_fn_args
 
+        for name, filter_fn in filters.items():
+            env.filters[name] = filter_fn
+
         return env.from_string(cleaned_template)
 
     @classmethod
-    def _template_from_file(_, path: Path) -> jinja2.Template:
+    def _template_from_file(_, path: Path, **filters: Dict[str, Callable]) -> jinja2.Template:
         file_directory = os.path.dirname(os.path.abspath(path))
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(file_directory),
@@ -118,10 +121,14 @@ class Prompt:
             keep_trailing_newline=True,
             undefined=jinja2.StrictUndefined,
         )
+
+        for name, filter_fn in filters.items():
+            env.filters[name] = filter_fn
+
         return env.get_template(os.path.basename(path))
 
 
-def prompt(fn: Callable) -> Prompt:
+def prompt(fn: Optional[Callable] = None, **filters: Dict[str, Callable]) -> Callable:
     """Decorate a function that contains a prompt template.
 
     This allows to define prompts in the docstring of a function and simplify their
@@ -152,11 +159,26 @@ def prompt(fn: Callable) -> Prompt:
     ...
     >>> hal = ft.partial(solve_task, "HAL", "Travel to Jupiter")
 
+    Additional Jinja2 filters can be provided as keyword arguments to the decorator.
+
+    >>> def reverse_string(s: str) -> str:
+    ...     return s[::-1]
+    ...
+    >>> @outlines.prompt(reverse=reverse_string)
+    ... def reverse_prompt(text):
+    ...     '''{{ text | reverse }}'''
+    ...
+    >>> prompt = reverse_prompt("Hello")
+    >>> print(prompt)
+    ... "olleH"
+
     Returns
     -------
     A `Prompt` callable class which will render the template when called.
 
     """
+    if fn is None:
+        return lambda fn: prompt(fn, **filters)
 
     signature = inspect.signature(fn)
 
@@ -166,7 +188,7 @@ def prompt(fn: Callable) -> Prompt:
     if docstring is None:
         raise TypeError("Could not find a template in the function's docstring.")
 
-    template = Prompt._template_from_str(cast(str, docstring))
+    template = Prompt._template_from_str(cast(str, docstring), **filters)
 
     return Prompt(template, signature)
 

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -135,9 +135,7 @@ class Prompt:
 
 
 def prompt(
-    fn_or_filters: Optional[
-        Union[Callable, List[Callable], Dict[str, Callable]]
-    ] = None,
+    fn: Optional[Callable] = None,
     filters: Union[List[Callable], Dict[str, Callable]] = [],
 ) -> Callable:
     """Decorate a function that contains a prompt template.
@@ -175,7 +173,7 @@ def prompt(
     >>> def reverse(s: str) -> str:
     ...     return s[::-1]
     ...
-    >>> @outlines.prompt([reverse])
+    >>> @outlines.prompt(filters=[reverse])
     ... def reverse_prompt(text):
     ...     '''{{ text | reverse }}'''
     ...
@@ -188,16 +186,16 @@ def prompt(
     A `Prompt` callable class which will render the template when called.
 
     """
-    if not callable(fn_or_filters):
+    if fn is None:
         return lambda fn: prompt(
-            fn, cast(Union[List[Callable], Dict[str, Callable]], fn_or_filters)
+            fn, cast(Union[List[Callable], Dict[str, Callable]], filters)
         )
 
-    signature = inspect.signature(fn_or_filters)
+    signature = inspect.signature(fn)
 
     # The docstring contains the template that will be rendered to be used
     # as a prompt to the language model.
-    docstring = fn_or_filters.__doc__
+    docstring = fn.__doc__
     if docstring is None:
         raise TypeError("Could not find a template in the function's docstring.")
 

--- a/outlines/prompts.py
+++ b/outlines/prompts.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, List, Dict, Optional, Type, cast, Union
+from typing import Any, Callable, Dict, Optional, Type, cast
 
 import jinja2
 import pydantic
@@ -78,7 +78,9 @@ class Prompt:
         return cls(cls._template_from_file(path, **filters), None)
 
     @classmethod
-    def _template_from_str(_, content: str, **filters: Dict[str, Callable]) -> jinja2.Template:
+    def _template_from_str(
+        _, content: str, **filters: Dict[str, Callable]
+    ) -> jinja2.Template:
         # Dedent, and remove extra linebreak
         cleaned_template = inspect.cleandoc(content)
 
@@ -112,7 +114,9 @@ class Prompt:
         return env.from_string(cleaned_template)
 
     @classmethod
-    def _template_from_file(_, path: Path, **filters: Dict[str, Callable]) -> jinja2.Template:
+    def _template_from_file(
+        _, path: Path, **filters: Dict[str, Callable]
+    ) -> jinja2.Template:
         file_directory = os.path.dirname(os.path.abspath(path))
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(file_directory),

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -321,6 +321,22 @@ def test_prompt_args():
     )
 
 
+def test_prompt_with_additional_filters():
+    def reverse_string(s: str) -> str:
+        return s[::-1]
+
+    @outlines.prompt(reverse=reverse_string)
+    def test_tpl(variable):
+        """{{ variable | reverse }} test"""
+
+    assert list(test_tpl.signature.parameters) == ["variable"]
+
+    p = test_tpl("test")
+    assert p == "tset test"
+
+    p = test_tpl(variable="example")
+    assert p == "elpmaxe test"
+
 @pytest.fixture
 def temp_prompt_file():
     test_dir = tempfile.mkdtemp()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -321,11 +321,28 @@ def test_prompt_args():
     )
 
 
-def test_prompt_with_additional_filters():
-    def reverse_string(s: str) -> str:
+def test_prompt_with_additional_filters_as_dict():
+    def reverse(s: str) -> str:
         return s[::-1]
 
-    @outlines.prompt(reverse=reverse_string)
+    @outlines.prompt(dict(reverse=reverse))
+    def test_tpl(variable):
+        """{{ variable | reverse }} test"""
+
+    assert list(test_tpl.signature.parameters) == ["variable"]
+
+    p = test_tpl("test")
+    assert p == "tset test"
+
+    p = test_tpl(variable="example")
+    assert p == "elpmaxe test"
+
+
+def test_prompt_with_additional_filters_as_list():
+    def reverse(s: str) -> str:
+        return s[::-1]
+
+    @outlines.prompt([reverse])
     def test_tpl(variable):
         """{{ variable | reverse }} test"""
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -325,7 +325,7 @@ def test_prompt_with_additional_filters_as_dict():
     def reverse(s: str) -> str:
         return s[::-1]
 
-    @outlines.prompt(dict(reverse=reverse))
+    @outlines.prompt(filters=dict(reverse=reverse))
     def test_tpl(variable):
         """{{ variable | reverse }} test"""
 
@@ -342,7 +342,7 @@ def test_prompt_with_additional_filters_as_list():
     def reverse(s: str) -> str:
         return s[::-1]
 
-    @outlines.prompt([reverse])
+    @outlines.prompt(filters=[reverse])
     def test_tpl(variable):
         """{{ variable | reverse }} test"""
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -321,28 +321,11 @@ def test_prompt_args():
     )
 
 
-def test_prompt_with_additional_filters_as_dict():
+def test_prompt_with_additional_filters():
     def reverse(s: str) -> str:
         return s[::-1]
 
     @outlines.prompt(filters=dict(reverse=reverse))
-    def test_tpl(variable):
-        """{{ variable | reverse }} test"""
-
-    assert list(test_tpl.signature.parameters) == ["variable"]
-
-    p = test_tpl("test")
-    assert p == "tset test"
-
-    p = test_tpl(variable="example")
-    assert p == "elpmaxe test"
-
-
-def test_prompt_with_additional_filters_as_list():
-    def reverse(s: str) -> str:
-        return s[::-1]
-
-    @outlines.prompt(filters=[reverse])
     def test_tpl(variable):
         """{{ variable | reverse }} test"""
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -337,6 +337,7 @@ def test_prompt_with_additional_filters():
     p = test_tpl(variable="example")
     assert p == "elpmaxe test"
 
+
 @pytest.fixture
 def temp_prompt_file():
     test_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Allow giving custom filters to the prompt decorator

```
def reverses: str) -> str:
    return s[::-1]

@prompt(filters={ 'reverse': reverse })
def reverse_prompt(text):
    '''{{ text | reverse }}'''

prompt = reverse_prompt("Hello")

print(prompt)
>>> "olleH"
```