### PR TITLE
Remove incorrect text from feature matrix docs

### DIFF
--- a/docs/reference/models/models.md
+++ b/docs/reference/models/models.md
@@ -40,9 +40,8 @@ model = outlines.models.openai(
 | **Generation**    |              |                     |      |           |           |       |         |
 | Batch             | ✅           | ✅                  | ✅   | ❌        | ?         | ❌    | ❌      |
 | Stream            | ✅           | ❌                  | ❌   | ✅        | ?         | ✅    | ❌      |
-| **`outlines.generate`** |        |                     |      |           |           |       |         |
 | Text              | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ✅      |
-| __Structured__    | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ✅      |
+| **Structured**    | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ✅      |
 | JSON Schema       | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ✅      |
 | Choice            | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ✅      |
 | Regex             | ✅           | ✅                  | ✅   | ✅        | ✅        | ✅    | ❌      |


### PR DESCRIPTION
There's an extra `outlines.generate` row in the feature matrix docs. This removes it.

I also modified the markdown syntax for one header to use ** rather than __, consistent with the rest of the table.