### PR TITLE
Create a base class for the models

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -9,6 +9,7 @@ codebase.
 from typing import Union
 
 from .anthropic import Anthropic
+from .base import Model, ModelTypeAdapter
 from .exllamav2 import ExLlamaV2Model, exl2
 from .gemini import Gemini
 from .llamacpp import LlamaCpp

--- a/outlines/models/base.py
+++ b/outlines/models/base.py
@@ -1,0 +1,82 @@
+from abc import ABC, abstractmethod
+
+
+class ModelTypeAdapter(ABC):
+    """Base class for all model type adapters.
+
+    A type adapter instance must be given as a value to the `type_adapter`
+    attribute when instantiating a model.
+    The type adapter is responsible for formatting the input and output types
+    passed to the model to match the specific format expected by the
+    associated model.
+
+    """
+
+    @abstractmethod
+    def format_input(self, model_input):
+        """Format the user input to the expected format of the model.
+
+        For API-based models, it typically means creating the `messages`
+        argument passed to the client. For local models, it can mean casting
+        the input from str to list for instance.
+        This method is also used to validate that the input type provided by
+        the user is supported by the model.
+
+        """
+        ...
+
+    @abstractmethod
+    def format_output_type(self, output_type):
+        """Format the output type to the expected format of the model.
+
+        For API-based models, this typically means creating a `response_format`
+        argument. For local models, it means formatting the logits processor to
+        create the object type expected by the model.
+
+        """
+        ...
+
+
+class Model(ABC):
+    """Base class for all models.
+
+    This class defines a shared `__call__` method that can be used to call the
+    model directly.
+    All models inheriting from this class must define a `type_adapter`
+    attribute of type `ModelTypeAdapter`. The methods of the `type_adapter`
+    attribute are used in the `generate` method to format the input and output
+    types received by the model.
+
+    """
+
+    type_adapter: ModelTypeAdapter
+
+    def __call__(self, model_input, output_type=None, **inference_kwargs):
+        """Call the model.
+
+        Users can call the model directly, in which case we will create a
+        generator instance with the output type provided and call it.
+        Thus, those commands are equivalent:
+        ```python
+        generator = Generator(model, Foo)
+        generator("prompt")
+        ```
+        and
+        ```python
+        model("prompt", Foo)
+        ```
+
+        """
+        from outlines.generate import Generator
+
+        return Generator(self, output_type)(model_input, **inference_kwargs)
+
+    @abstractmethod
+    def generate(self, model_input, output_type=None, **inference_kwargs):
+        """Generate a response from the model.
+
+        The output_type argument contains a logits processor for local models
+        while it contains a type (Json, Enum...) for the API-based models.
+
+        """
+        ...

--- a/outlines/models/gemini.py
+++ b/outlines/models/gemini.py
@@ -7,17 +7,18 @@ from typing import Optional, Union
 from pydantic import BaseModel
 from typing_extensions import _TypedDictMeta  # type: ignore
 
+from outlines.models.base import Model, ModelTypeAdapter
 from outlines.prompts import Vision
 from outlines.types import Choice, Json, List
 
 __all__ = ["Gemini"]
 
 
-class GeminiBase:
-    """Base class for the Gemini clients.
+class GeminiTypeAdapter(ModelTypeAdapter):
+    """Type adapter for the Gemini clients.
 
-    `GeminiBase` is responsible for preparing the arguments to Gemini's
-    `generate_contents` methods: the input (prompt and possibly image), as well
+    `GeminiTypeAdapter` is responsible for preparing the arguments to Gemini's
+    `generate_content` methods: the input (prompt and possibly image), as well
     as the output type (only JSON).
 
     """
@@ -91,11 +92,13 @@ class GeminiBase:
         }
 
 
-class Gemini(GeminiBase):
+class Gemini(Model):
     def __init__(self, model_name: str, *args, **kwargs):
         import google.generativeai as genai
 
         self.client = genai.GenerativeModel(model_name, *args, **kwargs)
+        self.model_type = "api"
+        self.type_adapter = GeminiTypeAdapter()
 
     def generate(
         self,
@@ -105,9 +108,9 @@ class Gemini(GeminiBase):
     ):
         import google.generativeai as genai
 
-        contents = self.format_input(model_input)
+        contents = self.type_adapter.format_input(model_input)
         generation_config = genai.GenerationConfig(
-            **self.format_output_type(output_type)
+            **self.type_adapter.format_output_type(output_type)
         )
         completion = self.client.generate_content(
             generation_config=generation_config, **contents, **inference_kwargs

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -1,7 +1,9 @@
 import pickle
 import warnings
+from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Dict, Iterator, List, Set, Tuple, Union
 
+from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import Tokenizer
 
 if TYPE_CHECKING:
@@ -93,7 +95,49 @@ class LlamaCppTokenizer(Tokenizer):
         raise NotImplementedError("Cannot load a pickled llamacpp tokenizer")
 
 
-class LlamaCpp:
+class LlamaCppTypeAdapter(ModelTypeAdapter):
+    """Type adapter for the `llama-cpp-python` library.
+
+    `LlamaCppTypeAdapter` is responsible for preparing the arguments to
+    `llama-cpp-python`'s `Llama.__call__` method: the input (a string prompt),
+    as well as the logits processor (an instance of `LogitsProcessorList`).
+
+    """
+
+    @singledispatchmethod
+    def format_input(self, model_input):
+        """Generate the prompt argument to pass to the model.
+
+        Argument
+        --------
+        model_input
+            The input passed by the user.
+
+        """
+        raise NotImplementedError(
+            f"The input type {input} is not available. "
+            "The `llama-cpp-python` library does not support batch inference. "
+        )
+
+    @format_input.register(str)
+    def format_str_input(self, model_input: str):
+        return model_input
+
+    def format_output_type(self, output_type):
+        """Generate the logits processor argument to pass to the model.
+
+        Argument
+        --------
+        output_type
+            The logits processor provided.
+
+        """
+        from llama_cpp import LogitsProcessorList
+
+        return LogitsProcessorList([output_type])
+
+
+class LlamaCpp(Model):
     """Wraps a model provided by the `llama-cpp-python` library."""
 
     def __init__(self, model_path: Union[str, "Llama"], **kwargs):
@@ -115,6 +159,8 @@ class LlamaCpp:
             self.model = Llama(model_path, **kwargs)
 
         self.tokenizer = LlamaCppTokenizer(self.model)
+        self.model_type = "local"
+        self.type_adapter = LlamaCppTypeAdapter()
 
     @classmethod
     def from_pretrained(cls, repo_id, filename, **kwargs):
@@ -134,7 +180,7 @@ class LlamaCpp:
             model = Llama.from_pretrained(repo_id, filename, **kwargs)
             return cls(model)
 
-    def generate(self, prompt: str, logits_processor, **inference_kwargs) -> str:
+    def generate(self, model_input, logits_processor, **inference_kwargs):
         """Generate text using `llama-cpp-python`.
 
         Arguments
@@ -152,16 +198,9 @@ class LlamaCpp:
         The generated text.
 
         """
-        from llama_cpp import LogitsProcessorList
-
-        if not isinstance(prompt, str):
-            raise NotImplementedError(
-                "The `llama-cpp-python` library does not support batch inference."
-            )
-
         completion = self.model(
-            prompt,
-            logits_processor=LogitsProcessorList([logits_processor]),
+            self.type_adapter.format_input(model_input),
+            logits_processor=self.type_adapter.format_output_type(logits_processor),
             **inference_kwargs,
         )
         result = completion["choices"][0]["text"]
@@ -171,7 +210,7 @@ class LlamaCpp:
         return result
 
     def stream(
-        self, prompt: str, logits_processor, **inference_kwargs
+        self, model_input, logits_processor, **inference_kwargs
     ) -> Iterator[str]:
         """Stream text using `llama-cpp-python`.
 
@@ -190,16 +229,9 @@ class LlamaCpp:
         A generator that return strings.
 
         """
-        from llama_cpp import LogitsProcessorList
-
-        if not isinstance(prompt, str):
-            raise NotImplementedError(
-                "The `llama-cpp-python` library does not support batch inference."
-            )
-
         generator = self.model(
-            prompt,
-            logits_processor=LogitsProcessorList([logits_processor]),
+            self.type_adapter.format_input(model_input),
+            logits_processor=self.type_adapter.format_output_type(logits_processor),
             stream=True,
             **inference_kwargs,
         )

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -5,18 +5,19 @@ from typing import Optional, Union
 
 from pydantic import BaseModel
 
+from outlines.models.base import Model, ModelTypeAdapter
 from outlines.prompts import Vision
 from outlines.types import Json
 
 __all__ = ["OpenAI"]
 
 
-class OpenAIBase:
-    """Base class for the OpenAI clients.
+class OpenAITypeAdapter(ModelTypeAdapter):
+    """Type adapter for the OpenAI clients.
 
-    `OpenAI` base is responsible for preparing the arguments to OpenAI's
-    `completions.create` methods: the input (prompt and possibly image), as well
-    as the output type (only JSON).
+    `OpenAITypeAdapter` is responsible for preparing the arguments to OpenAI's
+    `completions.create` methods: the input (prompt and possibly image), as
+    well as the output type (only JSON).
 
     """
 
@@ -64,7 +65,7 @@ class OpenAIBase:
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": f"data:{model_input.image_format};base64,{model_input.image_str}"
+                                "url": f"data:{model_input.image_format};base64,{model_input.image_str}"  # noqa: E702
                             },
                         },
                     ],
@@ -114,7 +115,7 @@ class OpenAIBase:
         }
 
 
-class OpenAI(OpenAIBase):
+class OpenAI(Model):
     """Thin wrapper around the `openai.OpenAI` client.
 
     This wrapper is used to convert the input and output types specified by the
@@ -127,6 +128,8 @@ class OpenAI(OpenAIBase):
 
         self.client = OpenAI(*args, **kwargs)
         self.model_name = model_name
+        self.model_type = "api"
+        self.type_adapter = OpenAITypeAdapter()
 
     def generate(
         self,
@@ -134,8 +137,8 @@ class OpenAI(OpenAIBase):
         output_type: Optional[Union[type[BaseModel], str]] = None,
         **inference_kwargs,
     ):
-        messages = self.format_input(model_input)
-        response_format = self.format_output_type(output_type)
+        messages = self.type_adapter.format_input(model_input)
+        response_format = self.type_adapter.format_output_type(output_type)
         result = self.client.chat.completions.create(
             model=self.model_name, **messages, **response_format, **inference_kwargs
         )
@@ -156,3 +159,5 @@ class AzureOpenAI(OpenAI):
 
         self.client = AzureOpenAI(*args, **kwargs)
         self.model_name = deployment_name
+        self.model_type = "api"
+        self.type_adapter = OpenAITypeAdapter()

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -49,6 +49,13 @@ def test_anthropic_simple_call():
 
 
 @pytest.mark.api_call
+def test_anthropic_direct_call():
+    model = Anthropic(MODEL_NAME)
+    result = model("Respond with one word. Not more.")
+    assert isinstance(result, str)
+
+
+@pytest.mark.api_call
 def test_anthropic_simple_vision():
     model = Anthropic(MODEL_NAME)
 

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -34,6 +34,13 @@ def test_gemini_simple_call():
 
 
 @pytest.mark.api_call
+def test_gemini_direct_call():
+    model = Gemini(MODEL_NAME)
+    result = model("Respond with one word. Not more.")
+    assert isinstance(result, str)
+
+
+@pytest.mark.api_call
 def test_gemini_simple_vision():
     model = Gemini(MODEL_NAME)
 

--- a/tests/models/test_llamacpp.py
+++ b/tests/models/test_llamacpp.py
@@ -31,6 +31,11 @@ def test_llamacpp_simple(model):
     assert isinstance(result, str)
 
 
+def test_llamacpp_call(model):
+    result = model("Respond with one word. Not more.")
+    assert isinstance(result, str)
+
+
 def test_llamacpp_regex(model):
     regex_str = Regex(r"[0-9]").to_regex()
     logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -67,6 +67,13 @@ def test_openai_simple_call():
 
 
 @pytest.mark.api_call
+def test_openai_direct_call():
+    model = OpenAI(MODEL_NAME)
+    result = model("Respond with one word. Not more.")
+    assert isinstance(result, str)
+
+
+@pytest.mark.api_call
 def test_openai_simple_vision():
     model = OpenAI(MODEL_NAME)
 


### PR DESCRIPTION
Updated on 2025-02-11

The objective of this PR is to create a base class all models would inherit from. This base class defines the interface for models and includes a `__call__` method that allows models to be called with a prompt and output type directly following the suggestion in #1359 .

Formatting methods for the input and output types are implemented in a separate class inheriting from the base class `ModelTypeAdapter`. Each model must set a `type_adapter` attribute in its initialization. The rationale for separating those from the model class is that the accepted types for each model and the formatting logic are quite different concerns compared to the specifics of the model's implementation. Separating them also allows us to have an easier to read documentation of the accepted types for each model.

Another change proposed in this PR is to set a mandatory `model_type` attribute in each model class. This would allow us not to have to rely on a static list of models through the `APIModel` and `LocalModel` classes.

The use of the base model class is implemented for the models that have already been refactored: OpenAI, Gemini, Anthropic and Llamacpp.
