### PR TITLE
Update Dockerfile to Multi-Stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10
+### Build stage
+FROM python:3.10 AS builder
 
 WORKDIR /outlines
 
@@ -12,6 +13,11 @@ COPY outlines ./outlines
 # .git required by setuptools-scm
 RUN --mount=source=.git,target=.git,type=bind \
     pip install --no-cache-dir .[serve]
+
+### Runtime stage
+FROM python:3.10
+WORKDIR /outlines
+COPY --from=builder /outlines /outlines
 
 # https://dottxt-ai.github.io/outlines/reference/vllm/
 ENTRYPOINT ["python3", "-m", "outlines.serve.serve"]


### PR DESCRIPTION
Hi,

Thanks for maintaining outlines. I represent a research group investigating [multi-stage builds](https://docs.docker.com/build/building/multi-stage/). We recently refactored your Dockerfile to a multi-stage Dockerfile and found that it brings the following benefits: 

✅ Reduced final image size (from 7405MB to 957MB)  
✅ Minimized image vulnerabilities (verified via [Trivy](https://github.com/aquasecurity/trivy), from 1317 to 1141)  

We hope this small improvement to the Dockerfile will be useful to you :)

Thanks,