### PR TITLE
Create the CFG type to be used as an output type

### DIFF
--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -3,6 +3,7 @@ import warnings
 from typing import TYPE_CHECKING, Dict, Iterator, List, Set, Tuple, Union
 
 from outlines.models.tokenizer import Tokenizer
+from outlines.processors import CFGLogitsProcessor
 
 if TYPE_CHECKING:
     from llama_cpp import Llama
@@ -159,6 +160,11 @@ class LlamaCpp:
                 "The `llama-cpp-python` library does not support batch inference."
             )
 
+        if isinstance(logits_processor, CFGLogitsProcessor):
+            raise NotImplementedError(
+                "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
+            )
+
         completion = self.model(
             prompt,
             logits_processor=LogitsProcessorList([logits_processor]),
@@ -195,6 +201,11 @@ class LlamaCpp:
         if not isinstance(prompt, str):
             raise NotImplementedError(
                 "The `llama-cpp-python` library does not support batch inference."
+            )
+
+        if isinstance(logits_processor, CFGLogitsProcessor):
+            raise NotImplementedError(
+                "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
             )
 
         generator = self.model(

--- a/outlines/types/__init__.py
+++ b/outlines/types/__init__.py
@@ -103,3 +103,10 @@ class Regex:
 
     def to_regex(self):
         return self.definition
+
+
+@dataclass
+class CFG:
+    """Represents a Context-Free Grammar as a string."""
+
+    definition: str

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -167,3 +167,9 @@ def test_type_enum(custom_type, test_string, should_match):
     assert isinstance(format_fn(1), str)
     does_match = re.match(regex_str, test_string) is not None
     assert does_match is should_match
+
+
+def test_type_cfg():
+    cfg_str = "?start: expression"
+    cfg_type = types.CFG(cfg_str)
+    assert cfg_type.definition == cfg_str


### PR DESCRIPTION
This PR addresses issue #1300 

We create a new type `CFG` and update the `Generator` class to accept the `CFG` type (creating a `CFGLogitsProcessor`) on top of accepting regex-based types (creating a `RegexLogitsProcessor`)