### PR TITLE
Fix the failing tests on branch v1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         echo "::set-output name=id::$MATRIX_ID"
     - name: Run tests
       run: |
-        pytest --cov=outlines
+        pytest --cov=outlines -m "not api_call"
       env:
         COVERAGE_FILE: .coverage.${{ steps.matrix-id.outputs.id }}
     - name: Upload coverage data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
    "airportsdata",
    "torch",
    "outlines_core==0.1.17",
+   "datasets",
 ]
 dynamic = ["version"]
 

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -14,10 +14,14 @@ import outlines.samplers as samplers
 
 @pytest.fixture(scope="session")
 def model_llamacpp(tmp_path_factory):
-    return models.llamacpp(
+    from llama_cpp import Llama
+
+    llm = Llama.from_pretrained(
         repo_id="M4-ai/TinyMistral-248M-v2-Instruct-GGUF",
         filename="TinyMistral-248M-v2-Instruct.Q4_K_M.gguf",
+        verbose=False,
     )
+    return models.LlamaCpp(llm)
 
 
 @pytest.fixture(scope="session")
@@ -114,7 +118,7 @@ def model_t5(tmp_path_factory):
 
 
 ALL_MODEL_FIXTURES = (
-    "model_llamacpp",
+    # "model_llamacpp",  # temporary disabled due to the v1 model refactoring
     "model_exllamav2",
     "model_mlxlm",
     "model_mlxlm_phi3",

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 
 import PIL
 import pytest
@@ -13,34 +14,48 @@ from outlines.types import Json
 MODEL_NAME = "gpt-4o-mini-2024-07-18"
 
 
-def test_openai_wrong_init_parameters():
-    with pytest.raises(TypeError, match="got an unexpected"):
-        OpenAI(MODEL_NAME, foo=10)
+@pytest.fixture
+def api_key():
+    """Get the OpenAI API key from the environment, providing a default value if not found.
+
+    This fixture should be used for tests that do not make actual api calls,
+    but still require to initialize the OpenAI client.
+
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "MOCK_VALUE"
+    return api_key
 
 
-def test_openai_wrong_inference_parameters():
+def test_openai_wrong_init_parameters(api_key):
     with pytest.raises(TypeError, match="got an unexpected"):
-        model = OpenAI(MODEL_NAME)
+        OpenAI(MODEL_NAME, api_key=api_key, foo=10)
+
+
+def test_openai_wrong_inference_parameters(api_key):
+    with pytest.raises(TypeError, match="got an unexpected"):
+        model = OpenAI(MODEL_NAME, api_key=api_key)
         model.generate("prompt", foo=10)
 
 
-def test_openai_wrong_input_type():
+def test_openai_wrong_input_type(api_key):
     class Foo:
         def __init__(self, foo):
             self.foo = foo
 
     with pytest.raises(NotImplementedError, match="is not available"):
-        model = OpenAI(MODEL_NAME)
+        model = OpenAI(MODEL_NAME, api_key=api_key)
         model.generate(Foo("prompt"))
 
 
-def test_openai_wrong_output_type():
+def test_openai_wrong_output_type(api_key):
     class Foo:
         def __init__(self, foo):
             self.foo = foo
 
     with pytest.raises(NotImplementedError, match="is not available"):
-        model = OpenAI(MODEL_NAME)
+        model = OpenAI(MODEL_NAME, api_key=api_key)
         model.generate("prompt", Foo(1))
 
 


### PR DESCRIPTION
Tests are currently failing on branch v1.0, which is detrimental to visibility on whether the change proposed by our PRs to this branch are causing new test failures.

4 fixes:
- Add the package `datasets` as a dependency
- Skip tests marked as "api_call" in the CI
- Provide a mock api key value to the OpenAI client in tests that do not make actual api calls (otherwise it causes an error when initializing the client)
- Temporarily remove `LlamaCpp` from the list of model fixtures on which we run the generate tests as the refactored models are incompatible with those tests. On this topic, do you think it's fine to remove the models as we refactor them and then to completely rewrite the generate tests @rlouf (I would create an issue for that and add it to the v1.0 milestones)?