### PR TITLE
Fix cache dir, make it more robust when there is no $HOME

### DIFF
--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -51,16 +51,20 @@ def get_cache():
     """
     from outlines._version import __version__ as outlines_version  # type: ignore
 
+    outlines_cache_dir = os.environ.get('OUTLINES_CACHE_DIR')
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
-    if xdg_cache_home:
+    home_dir = os.path.normpath(os.path.expanduser("~"))
+    if outlines_cache_dir:
+        # OUTLINES_CACHE_DIR takes precendence
+        cache_dir = outlines_cache_dir
+    elif xdg_cache_home:
         cache_dir = os.path.join(xdg_cache_home, ".cache", "outlines")
+    elif home_dir != "/":
+        cache_dir = os.path.join(home_dir, ".cache", "outlines")
     else:
-        home_dir = os.path.normpath(os.path.expanduser("~"))
-        if home_dir != "/":
-            cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
-        else:
-            tempdir = tempfile.gettempdir()
-            cache_dir = os.path.join(tempdir, ".cache", "outlines")
+        # home_dir may be / inside a docker container without existing user
+        tempdir = tempfile.gettempdir()
+        cache_dir = os.path.join(tempdir, ".cache", "outlines")
 
     memory = Cache(
         cache_dir,

--- a/outlines/caching.py
+++ b/outlines/caching.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import functools
 import os
+import tempfile
 from typing import Callable, Optional
 
 import cloudpickle
@@ -50,8 +51,17 @@ def get_cache():
     """
     from outlines._version import __version__ as outlines_version  # type: ignore
 
-    home_dir = os.path.expanduser("~")
-    cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        cache_dir = os.path.join(xdg_cache_home, ".cache", "outlines")
+    else:
+        home_dir = os.path.normpath(os.path.expanduser("~"))
+        if home_dir != "/":
+            cache_dir = os.environ.get("OUTLINES_CACHE_DIR", f"{home_dir}/.cache/outlines")
+        else:
+            tempdir = tempfile.gettempdir()
+            cache_dir = os.path.join(tempdir, ".cache", "outlines")
+
     memory = Cache(
         cache_dir,
         eviction_policy="none",


### PR DESCRIPTION
Make cache dir more robust.

We observed that when starting a docker container with a non existing user inside the container (using -u) outlines would try to use /.cache/ as a cache directory which will give permission denied. This PR sets an order of preference for finding the cache home uses XDG_CACHE_HOME if available and OUTLINES_CACHE_DIR is not set.