### PR TITLE
Add Bluesky social media profile link to docs

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -135,8 +135,11 @@ better.
                 </div>
                 <div class="md-buttons">
                     <p>
-                        <a href="https://twitter.com/dottxtai" title="Follow us on X" target="_blank">
-                            Follow us on X
+                        Follow us on <a href="https://twitter.com/dottxtai" title="Follow us on X" target="_blank">
+                            X
+                        </a> and
+                        <a href="https://bsky.app/profile/dottxtai.bsky.social" title="Follow us on Bluesky" target="_blank">
+                            Bluesky
                         </a>
                     </p>
                 </div>


### PR DESCRIPTION
This PR adds a link in the docs to the social media profile of dottxt on the Bluesky social network alongside the existing link to the profile on X.

Preview of built docs:

![image](https://github.com/user-attachments/assets/0b77a3c1-e2bd-4a51-aa7d-c7e913c8916f)

