### PR TITLE
JSON schema error when using OpenAI with Pydantic model

### DIFF
--- a/outlines/generate/json.py
+++ b/outlines/generate/json.py
@@ -92,7 +92,9 @@ def json_openai(
         )
 
     if isinstance(schema_object, type(BaseModel)):
-        schema = pyjson.dumps(schema_object.model_json_schema())
+        schema = schema_object.model_json_schema()
+        schema["additionalProperties"] = False
+        schema = pyjson.dumps(schema)
         format_sequence = lambda x: schema_object.parse_raw(x)
     elif isinstance(schema_object, str):
         schema = schema_object


### PR DESCRIPTION
Running the example from the docs with OpenAI model raises a schema error in the API. Fixing this error might also address #1376 because the vendor has introduced Structured Generation which is mostly compatible with this library.

```
from pydantic import BaseModel
from outlines import models, generate

class User(BaseModel):
    name: str
    last_name: str
    id: int

model = models.openai("gpt-4o-mini")
generator = generate.json(model, User)
result = generator("Create a user profile with the fields name, last_name and id.")
```

This causes an error in the API:

```
Traceback (most recent call last):
  File "/Users/frederikfix/src/konvenit/odin/scratch/mytest.py", line 55, in <module>
    result    = generator("Create a user profile with the fields name, last_name and id.")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/models/openai.py", line 146, in __call__
    response, prompt_tokens, completion_tokens = generate_chat(
                                                 ^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/base.py", line 72, in __call__
    return self.call_with_signature(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/base.py", line 177, in call_with_signature
    outputs = self.vectorize_call_coroutine(broadcast_shape, args, kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/base.py", line 266, in vectorize_call_coroutine
    outputs = loop.run_until_complete(create_and_gather_tasks())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/3.12.2/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/base.py", line 260, in create_and_gather_tasks
    outputs = await asyncio.gather(*tasks)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/models/openai.py", line 214, in generate_chat
    responses = await call_api(prompt, system_prompt, config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/caching.py", line 107, in wrapper
    result = await cached_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/outlines/models/openai.py", line 202, in call_api
    responses = await client.chat.completions.create(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py", line 1927, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/openai/_base_client.py", line 1862, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/openai/_base_client.py", line 1556, in request
    return await self._request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/openai/_base_client.py", line 1657, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid schema for response_format 'default': In context=(), 'additionalProperties' is required to be supplied and to be false.", 'type': 'invalid_request_error', 'param': 'response_format', 'code': None}}
```
