### PR TITLE
Tweak version commands in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,9 +63,9 @@ body:
       label: "Outlines/Python version information:"
       description: |
           Please run the following code and paste the output here.
-          python -c "from outlines import _version; print(_version.__version__)"
-          python -c "import sys; print('Python', sys.version)"
-          pip freeze
+          python -c "from outlines import _version; print(_version.__version__)";
+          python -c "import sys; print('Python', sys.version)";
+          pip freeze;
       value: |
           Version information
           <details>


### PR DESCRIPTION
The way these commands show up when a user fills out a new bug report is misleading, as they all get mashed into one line.

![Screenshot 2025-03-05 at 11 50 22 AM](https://github.com/user-attachments/assets/55e2af28-9b08-4948-8d9b-9c5b0ae81c9a)

Copy-pasting this results in only the first command running, which is presumably not what the template author intended.