### PR TITLE
Add stream method to Generator and Model classes

### DIFF
--- a/outlines/generator.py
+++ b/outlines/generator.py
@@ -38,6 +38,9 @@ class BlackBoxGenerator:
     def __call__(self, prompt, **inference_kwargs):
         return self.model.generate(prompt, self.output_type, **inference_kwargs)
 
+    def stream(self, prompt, **inference_kwargs):
+        return self.model.generate_stream(prompt, self.output_type, **inference_kwargs)
+
 
 @dataclass
 class SteerableGenerator:
@@ -78,6 +81,9 @@ class SteerableGenerator:
 
     def __call__(self, prompt, **inference_kwargs):
         return self.model.generate(prompt, self.logits_processor, **inference_kwargs)
+
+    def stream(self, prompt, **inference_kwargs):
+        return self.model.generate_stream(prompt, self.logits_processor, **inference_kwargs)
 
 
 def Generator(

--- a/outlines/models/anthropic.py
+++ b/outlines/models/anthropic.py
@@ -107,6 +107,25 @@ class Anthropic(Model):
         )
         return completion.content[0].text
 
+    def generate_stream(
+        self, model_input: Union[str, Vision], output_type=None, **inference_kwargs
+    ):
+        messages = self.type_adapter.format_input(model_input)
+
+        if output_type is not None:
+            raise NotImplementedError(
+                f"The type {output_type} is not available with Anthropic."
+            )
+
+        completion = self.client.messages.stream(
+            **messages,
+            model=self.model_name,
+            **inference_kwargs,
+        )
+        for chunk in completion:
+            if chunk.type == "content_block_delta":
+                yield chunk.delta.text
+
 
 def from_anthropic(client: "AnthropicClient", model_name: str) -> Anthropic:
     return Anthropic(client, model_name)

--- a/outlines/models/base.py
+++ b/outlines/models/base.py
@@ -71,12 +71,47 @@ class Model(ABC):
 
         return Generator(self, output_type)(model_input, **inference_kwargs)
 
+    def stream(self, model_input, output_type=None, **inference_kwargs):
+        """Stream a response from the model.
+
+        Users can use the `stream` method from the model directly, in which
+        case we will create a generator instance with the output type provided
+        and then invoke its `stream` method.
+        Thus, those commands are equivalent:
+        ```python
+        generator = Generator(model, Foo)
+        for chunk in generator("prompt"):
+            print(chunk)
+        ```
+        and
+        ```python
+        for chunk in model.stream("prompt", Foo):
+            print(chunk)
+        ```
+
+        """
+        from outlines import Generator
+
+        return Generator(self, output_type).stream(model_input, **inference_kwargs)
+
     @abstractmethod
     def generate(self, model_input, output_type=None, **inference_kwargs):
         """Generate a response from the model.
 
         The output_type argument contains a logits processor for local models
         while it contains a type (Json, Enum...) for the API-based models.
+        This method is not intended to be used directly by end users.
+
+        """
+        ...
+
+    @abstractmethod
+    def generate_stream(self, model_input, output_type=None, **inference_kwargs):
+        """Generate a stream of responses from the model.
+
+        The output_type argument contains a logits processor for local models
+        while it contains a type (Json, Enum...) for the API-based models.
+        This method is not intended to be used directly by end users.
 
         """
         ...

--- a/outlines/models/dottxt.py
+++ b/outlines/models/dottxt.py
@@ -92,6 +92,12 @@ class Dottxt(Model):
         )
         return completion.data
 
+    def generate_stream(self, model_input, output_type=None, **inference_kwargs):
+        raise NotImplementedError(
+            "Dottxt does not support streaming. Call the model/generator for "
+            + "regular generation instead."
+        )
+
 
 def from_dottxt(
     client: "DottxtClient",

--- a/outlines/models/gemini.py
+++ b/outlines/models/gemini.py
@@ -114,11 +114,36 @@ class Gemini(Model):
         generation_config = genai.GenerationConfig(
             **self.type_adapter.format_output_type(output_type)
         )
+
         completion = self.client.generate_content(
             generation_config=generation_config, **contents, **inference_kwargs
         )
 
         return completion.text
+
+    def generate_stream(
+        self,
+        model_input: Union[str, Vision],
+        output_type: Optional[Union[JsonType, Choice, List]] = None,
+        **inference_kwargs,
+    ):
+        import google.generativeai as genai
+
+        contents = self.type_adapter.format_input(model_input)
+        generation_config = genai.GenerationConfig(
+            **self.type_adapter.format_output_type(output_type)
+        )
+
+        stream = self.client.generate_content(
+            generation_config=generation_config,
+            **contents,
+            **inference_kwargs,
+            stream=True,
+        )
+
+        for chunk in stream:
+            if hasattr(chunk, "text") and chunk.text:
+                yield chunk.text
 
 
 def from_gemini(client: "GeminiClient"):

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -149,14 +149,14 @@ class LlamaCpp(Model):
         self.model_type = "local"
         self.type_adapter = LlamaCppTypeAdapter()
 
-    def generate(self, model_input, logits_processor, **inference_kwargs):
+    def generate(self, model_input, output_type, **inference_kwargs):
         """Generate text using `llama-cpp-python`.
 
         Arguments
         ---------
         prompt
             A prompt.
-        logits_processor
+        output_type
             The logits processor to use when generating text.
         inference_kwargs
             The inference kwargs that can be passed to the `Llama.__call__` method
@@ -167,14 +167,14 @@ class LlamaCpp(Model):
         The generated text.
 
         """
-        if isinstance(logits_processor, CFGLogitsProcessor):
+        if isinstance(output_type, CFGLogitsProcessor):
             raise NotImplementedError(
                 "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
             )
 
         completion = self.model(
             self.type_adapter.format_input(model_input),
-            logits_processor=self.type_adapter.format_output_type(logits_processor),
+            logits_processor=self.type_adapter.format_output_type(output_type),
             **inference_kwargs,
         )
         result = completion["choices"][0]["text"]
@@ -183,16 +183,16 @@ class LlamaCpp(Model):
 
         return result
 
-    def stream(
-        self, model_input, logits_processor, **inference_kwargs
-    ) -> Iterator[str]:
+    def generate_stream(
+        self, model_input, output_type, **inference_kwargs
+    ):
         """Stream text using `llama-cpp-python`.
 
         Arguments
         ---------
         prompt
             A prompt.
-        logits_processor
+        output_type
             The logits processor to use when generating text.
         inference_kwargs
             The inference kwargs that can be passed to the `Llama.__call__` method
@@ -203,14 +203,14 @@ class LlamaCpp(Model):
         A generator that return strings.
 
         """
-        if isinstance(logits_processor, CFGLogitsProcessor):
+        if isinstance(output_type, CFGLogitsProcessor):
             raise NotImplementedError(
                 "CFG generation is not supported for LlamaCpp due to bug in the llama_cpp tokenizer"
             )
 
         generator = self.model(
             self.type_adapter.format_input(model_input),
-            logits_processor=self.type_adapter.format_output_type(logits_processor),
+            logits_processor=self.type_adapter.format_output_type(output_type),
             stream=True,
             **inference_kwargs,
         )

--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -74,7 +74,7 @@ class MLXLM(Model):
         self.tokenizer = TransformerTokenizer(tokenizer._tokenizer)
         self.type_adapter = MLXLMTypeAdapter()
 
-    def generate(self, model_input, output_type, **kwargs):
+    def generate(self, model_input, output_type=None, **kwargs):
         """Generate text using `mlx-lm`.
 
         Arguments
@@ -97,7 +97,7 @@ class MLXLM(Model):
             **kwargs,
         )
 
-    def stream(self, model_input, output_type, **kwargs):
+    def generate_stream(self, model_input, output_type=None, **kwargs):
         """Stream text using `mlx-lm`.
 
         Arguments

--- a/outlines/models/ollama.py
+++ b/outlines/models/ollama.py
@@ -79,7 +79,7 @@ class Ollama(Model):
         )
         return response.response
 
-    def stream(self, model_input, output_type=None, **kwargs) -> Iterator[str]:
+    def generate_stream(self, model_input, output_type=None, **kwargs) -> Iterator[str]:
         response = self.client.generate(
             model=self.model_name,
             prompt=self.type_adapter.format_input(model_input),

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -151,6 +151,26 @@ class OpenAI(Model):
 
         return result.choices[0].message.content
 
+    def generate_stream(
+        self,
+        model_input: Union[str, Vision],
+        output_type: Optional[Union[type[BaseModel], str]] = None,
+        **inference_kwargs,
+    ):
+        messages = self.type_adapter.format_input(model_input)
+        response_format = self.type_adapter.format_output_type(output_type)
+        stream = self.client.chat.completions.create(
+            model=self.model_name,
+            stream=True,
+            **messages,
+            **response_format,
+            **inference_kwargs
+        )
+
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content is not None:
+                yield chunk.choices[0].delta.content
+
 
 def from_openai(
     client: Union["OpenAIClient", "AzureOpenAIClient"], model_name: str

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -214,7 +214,7 @@ class Transformers(Model):
 
         return self._decode_generation(generated_ids)
 
-    def stream(self, model_input, output_type, **inference_kwargs):
+    def generate_stream(self, model_input, output_type, **inference_kwargs):
         """
         TODO: implement following completion of https://github.com/huggingface/transformers/issues/30810
         """

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -126,7 +126,7 @@ class VLLM(Model):
 
         return results
 
-    def stream(self, model_input, output_type, **inference_kwargs):
+    def generate_stream(self, model_input, output_type, **inference_kwargs):
         """Return a text generator.
 
         Streaming is not yet available for `vllm.LLM`.

--- a/tests/models/test_dottxt.py
+++ b/tests/models/test_dottxt.py
@@ -69,7 +69,7 @@ def test_dottxt_wrong_inference_parameters(api_key):
 @pytest.mark.api_call
 def test_dottxt_direct_call(api_key):
     client = DottxtClient(api_key=api_key)
-    model = Dottxt(client, model_name="meta-llama/Llama-3.1-8B-Instruct")
+    model = Dottxt(client)
     result = model("Create a user", JsonType(User))
     assert "first_name" in json.loads(result)
 
@@ -77,7 +77,14 @@ def test_dottxt_direct_call(api_key):
 @pytest.mark.api_call
 def test_dottxt_generator_call(api_key):
     client = DottxtClient(api_key=api_key)
-    model = Dottxt(client, model_name="meta-llama/Llama-3.1-8B-Instruct")
+    model = Dottxt(client)
     generator = Generator(model, JsonType(User))
     result = generator("Create a user")
     assert "first_name" in json.loads(result)
+
+
+def test_dottxt_streaming(api_key):
+    client = DottxtClient(api_key=api_key)
+    model = Dottxt(client)
+    with pytest.raises(NotImplementedError, match="Dottxt does not support streaming"):
+        model.stream("Create a user", JsonType(User))

--- a/tests/models/test_llamacpp.py
+++ b/tests/models/test_llamacpp.py
@@ -91,9 +91,7 @@ def test_llamacpp_stream_simple(model):
 
 
 def test_llamacpp_stream_regex(model):
-    regex_str = Regex(r"[0-9]").pattern
-    logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer)
-    generator = model.stream("Respond with one word. Not more.", logits_processor)
+    generator = model.stream("Respond with one word. Not more.", Regex(r"[0-9]"))
 
     x = next(generator)
     assert isinstance(x, str)
@@ -103,9 +101,7 @@ def test_llamacpp_stream_json(model):
     class Foo(BaseModel):
         bar: int
 
-    regex_str = JsonType(Foo).to_regex()
-    logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer)
-    generator = model.stream("foo?", logits_processor)
+    generator = model.stream("foo?", JsonType(Foo))
 
     x = next(generator)
     assert x == "{"
@@ -116,9 +112,7 @@ def test_llamacpp_stream_choice(model):
         bar = "Bar"
         foor = "Foo"
 
-    regex_str = Choice(Foo).to_regex()
-    logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer)
-    generator = model.stream("foo?", logits_processor)
+    generator = model.stream("foo?", Choice(Foo))
 
     x = next(generator)
     assert isinstance(x, str)

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -1,6 +1,7 @@
 import pytest
 import re
 from enum import Enum
+from typing import Generator
 
 import outlines
 from outlines.types import Choice, JsonType, Regex
@@ -100,3 +101,12 @@ def test_mlxlm_choice(model):
 
     result = model("Cat or dog?", Choice(Foo))
     assert result in ["cat", "dog"]
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
+def test_mlxlm_stream_text_stop(model):
+    generator = model.stream(
+        "Respond with one word. Not more.", None, max_tokens=100
+    )
+    assert isinstance(generator, Generator)
+    assert isinstance(next(generator), str)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1,7 +1,7 @@
 import io
 import json
 import os
-
+from typing import Generator
 import PIL
 import pytest
 import requests
@@ -133,3 +133,12 @@ def test_openai_simple_json_schema():
     result = model.generate("foo?", JsonType(schema))
     assert isinstance(result, str)
     assert "bar" in json.loads(result)
+
+
+@pytest.mark.api_call
+def test_openai_streaming():
+    model = OpenAI(OpenAIClient(), MODEL_NAME)
+
+    result = model.stream("Respond with one word. Not more.")
+    assert isinstance(result, Generator)
+    assert isinstance(next(result), str)

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -146,3 +146,8 @@ def test_transformers_batch_samples_constrained(model):
         assert len(item) == 2
         assert item[0] in ["cat", "dog"]
         assert item[1] in ["cat", "dog"]
+
+
+def test_transformers_streaming(model):
+    with pytest.raises(NotImplementedError, match="Streaming is not implemented"):
+        model.stream("Respond with one word. Not more.")

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -133,3 +133,8 @@ def test_vllm_batch_samples_constrained(model):
         assert len(item) == 2
         assert item[0] in ["cat", "dog"]
         assert item[1] in ["cat", "dog"]
+
+
+def test_vllm_streaming(model):
+    with pytest.raises(NotImplementedError, match="Streaming is not implemented"):
+        model.stream("Respond with one word. Not more.")


### PR DESCRIPTION
Addresses issue #1482 

This PR aims at standardizing the use of streaming in our models and at aligning it on the functioning of the regular text generation. 3 changes:
- Add a `generate_stream` abstract method to the `Model` parent class and implement it in all models
- Add a `stream` method to the `Generator` classes that invokes the `generate_stream` method of the underlying model
- Add a `stream` method to the `Model` parent class that creates a `Generator` and then invokes its `stream` method
Thus, we end up having exactly the same system as with the `__call__` and `generate` methods for regular text generation.

It also modifies the models' tests.