### PR TITLE
Modify TransformersMultiModalTypeAdapter to make it more flexible

### DIFF
--- a/docs/reference/models/transformers_multimodal.md
+++ b/docs/reference/models/transformers_multimodal.md
@@ -21,21 +21,28 @@ model = models.from_transformers(
 )
 ```
 
-You must provider a processor adapted to your model. We currently only support vision and audio models.
+You must provider a processor adapted to your model. We currently offer official support for vision and audio models only, but you can use this class for any type of multimodal model (for instance video) as long as you provide the appropriate processor for your transformers model.
 
-## Use the model to generate text from prompts and images/audios
+## Use the model to generate text from prompts and assets
 
 When calling the model, the prompt argument you provide must be a dictionary using the following format:
 ```
 {
     "text": Union[str, List[str]],
-    "images": Optional[Union[Any, List[Any]]],
-    "audios": Optional[Union[Any, List[Any]]],
+    "...": Any
 }
 ```
 
-The `text` key is required. Either the `images` or `audios` key must be provided.
-The format and values of those keys must correspond to what you would provide to the `__call__` method of the processor if you were to call it directly. Thus, the text prompt must include the appropriate tags to indicate where the images or audios should be inserted (e.g. `<image>` or `<|AUDIO|>`).
+The `text` key is mandatory. Other keys are optional and depend on the processor you are using.
+The format and values of those keys must correspond to what you would provide to the `__call__` method of the processor if you were to call it directly. Thus, the text prompt must include the appropriate tags to indicate where the assets should be inserted (e.g. `<image>` or `<|AUDIO|>`).
+
+Example of a correctly formatted prompt for a vision model:
+```
+{
+    "text": "<image>Describe this image in one sentence:",
+    "images": PIL.Image.Image
+}
+```
 
 ### Vision models
 

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -271,26 +271,21 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
         """
         raise NotImplementedError(
             f"The input type {input} is not available. Please provide a "
-            "dictionary with the following format: "
-            "{'text': Union[str, List[str]], 'images': Optional[Union[Any, "
-            "List[Any]]], 'audios': Optional[Union[Any, List[Any]]]}"
-            "Either 'images' or 'audios' must be provided."
-            "Make sure the text is formatted correctly for the model "
-            "(e.g. include <image> or <|AUDIO|> tags)."
+            + "dictionary containing at least the 'text' key with a value "
+            + "of type Union[str, List[str]]. You should also include the "
+            + "other keys required by your processor (for instance, 'images' "
+            + "or 'audios')."
+            + "Make sure that the text is correctly formatted for the model "
+            + "(e.g. include <image> or <|AUDIO|> tags) and that the number "
+            + "of text tags match the number of additional assets provided."
         )
 
     @format_input.register(dict)
     def format_list_input(self, model_input):
-        if (
-            "text" not in model_input
-            or (
-                "images" not in model_input
-                and "audios" not in model_input
-            )
-        ):
+        if "text" not in model_input:
             raise ValueError(
-                "The input must contain the 'text' key along with either "
-                "'images' or 'audios'."
+                "The input must contain the 'text' key along with the other "
+                + "keys required by your processor."
             )
         return model_input
 


### PR DESCRIPTION
Addresses #1304 

The objective of this PR is to allow users to provide a wider range of possible inputs to a `TransformersMultiModal` model. The rationale behind it is that we want users to be able to use the class with as many models/generators as possible (for instance video) without having to explicitly cover this use case in the type adapter.

Overall, this change removes some safeguards on the model input to give more freedom to the end user. I think this is justified by the fact that multimodal transformers models are an advanced use case for which it's hard for us to anticipate all needs of users.