### PR TITLE
Add library specific handling of tensors in logits processors

### DIFF
--- a/outlines/generator.py
+++ b/outlines/generator.py
@@ -66,15 +66,17 @@ class SteerableGenerator:
             if isinstance(term, CFG):
                 cfg_string = term.definition
                 self.logits_processor = CFGLogitsProcessor(
-                    cfg_string, self.model.tokenizer
+                    cfg_string, self.model.tokenizer, self.model.tensor_library_name
                 )
             elif isinstance(term, FSM):
                 guide = RegexGuide.from_interegular_fsm(term.fsm, self.model.tokenizer)
-                self.logits_processor = GuideLogitsProcessor(tokenizer=self.model.tokenizer, guide=guide)
+                self.logits_processor = GuideLogitsProcessor(
+                    self.model.tokenizer, guide, self.model.tensor_library_name
+                )
             else:
                 regex_string = to_regex(term)
                 self.logits_processor = RegexLogitsProcessor(
-                    regex_string, self.model.tokenizer
+                    regex_string, self.model.tokenizer, self.model.tensor_library_name
                 )
 
     @classmethod

--- a/outlines/models/base.py
+++ b/outlines/models/base.py
@@ -46,10 +46,11 @@ class Model(ABC):
     attribute of type `ModelTypeAdapter`. The methods of the `type_adapter`
     attribute are used in the `generate` method to format the input and output
     types received by the model.
+    Additionally, local models must define a `tensor_library_name` attribute.
 
     """
-
     type_adapter: ModelTypeAdapter
+    tensor_library_name: str
 
     def __call__(self, model_input, output_type=None, **inference_kwargs):
         """Call the model.

--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -1,7 +1,7 @@
 import pickle
 import warnings
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Dict, Iterator, List, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import Tokenizer
@@ -140,13 +140,13 @@ class LlamaCppTypeAdapter(ModelTypeAdapter):
 
 class LlamaCpp(Model):
     """Wraps a model provided by the `llama-cpp-python` library."""
+    tensor_library_name = "numpy"
 
     def __init__(self, model: "Llama"):
         from llama_cpp import Llama
 
         self.model = model
         self.tokenizer = LlamaCppTokenizer(self.model)
-        self.model_type = "local"
         self.type_adapter = LlamaCppTypeAdapter()
 
     def generate(self, model_input, output_type, **inference_kwargs):

--- a/outlines/models/mlxlm.py
+++ b/outlines/models/mlxlm.py
@@ -50,6 +50,7 @@ class MLXLMTypeAdapter(ModelTypeAdapter):
 
 class MLXLM(Model):
     """Represents an `mlx_lm` model."""
+    tensor_library_name = "mlx"
 
     def __init__(
         self,

--- a/outlines/models/tokenizer.py
+++ b/outlines/models/tokenizer.py
@@ -1,7 +1,9 @@
-from typing import Dict, Hashable, List, Protocol, Set, Tuple, Union
+from typing import Dict, Hashable, List, Protocol, Set, Tuple, Union, TYPE_CHECKING
 
-import numpy as np
-from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 
 class Tokenizer(Hashable, Protocol):
@@ -13,11 +15,11 @@ class Tokenizer(Hashable, Protocol):
 
     def encode(
         self, prompt: Union[str, List[str]]
-    ) -> Tuple[NDArray[np.int64], NDArray[np.int64]]:
+    ) -> "Tuple['NDArray[np.int64]', 'NDArray[np.int64]']":
         """Translate the input prompts into arrays of token ids and attention mask."""
         ...
 
-    def decode(self, token_ids: NDArray[np.int64]) -> List[str]:
+    def decode(self, token_ids: "NDArray[np.int64]") -> List[str]:
         """Translate an array of token ids to a string or list of strings."""
         ...
 

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -189,12 +189,12 @@ class Transformers(Model):
         # is not available in the environment.
         try:
             from transformers import FlaxPreTrainedModel
-        except ImportError:
+        except ImportError:  # pragma: no cover
             FlaxPreTrainedModel = None
 
         try:
             from transformers import TFPreTrainedModel
-        except ImportError:
+        except ImportError:  # pragma: no cover
             TFPreTrainedModel = None
 
         tokenizer.padding_size = "left"

--- a/outlines/models/vllm.py
+++ b/outlines/models/vllm.py
@@ -53,6 +53,7 @@ class VLLMTypeAdapter(ModelTypeAdapter):
 
 class VLLM(Model):
     """Represents a `vllm` model."""
+    tensor_library_name = "torch"
 
     def __init__(self, model: "LLM"):
         """Create a VLLM model instance.

--- a/outlines/processors/structured.py
+++ b/outlines/processors/structured.py
@@ -25,16 +25,15 @@ limitations under the License.
 """
 
 import math
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
-import torch
 from outlines_core.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
 
 from outlines.processors.guide import CFGGuide, Guide, RegexGuide
 from outlines.types import JsonSchema
 
-from .base_logits_processor import OutlinesLogitsProcessor
+from .base_logits_processor import OutlinesLogitsProcessor, TensorType
 
 if TYPE_CHECKING:
     from outlines.models.tokenizer import Tokenizer
@@ -56,7 +55,7 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
     _guide_states: Dict[int, Any]
     _seq_start_idx: Optional[int]
 
-    def __init__(self, tokenizer: "Tokenizer", guide: Guide):
+    def __init__(self, tokenizer: "Tokenizer", guide: Guide, tensor_library_name: str):
         """A Guide-based logits processor.
 
         Parameters
@@ -65,15 +64,18 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
             The tokenizer used to convert tokens to ids.
         guide
             The `outlines.processors.guide. which is used to bias the logits.
+        tensor_library_name
+            The name of the library to use to manipulate the tensors.
         """
+        super().__init__(tensor_library_name=tensor_library_name)
         self.tokenizer = tokenizer
         self.guide = guide
         self._guide_states = {hash(tuple([])): self.guide.initial_state}
         self._seq_start_idx = None
 
     def process_logits(
-        self, input_ids: torch.LongTensor, logits: torch.FloatTensor
-    ) -> torch.Tensor:
+        self, input_ids: TensorType, logits: TensorType
+    ) -> TensorType:
         """Use the Guide to bias the logits before sampling the next token.
 
         Parameters
@@ -85,21 +87,20 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
 
         Returns
         -------
-        torch.Tensor
-            The biased logits.
+        The biased logits.
         """
         if self._seq_start_idx is None:
-            self._seq_start_idx = len(input_ids[0])
+            self._seq_start_idx = len(input_ids[0]) # type: ignore
 
         sequence_states: List[int] = []  # vector of states corresponding to `input_ids`
 
-        for seq_ids in input_ids:
+        for seq_ids in input_ids: # type: ignore
             gen_ids = seq_ids[self._seq_start_idx :]
-            curr_state_key = hash(tuple(gen_ids.tolist()))
+            curr_state_key = hash(tuple(self.tensor_adapter.to_list(gen_ids)))
 
             if curr_state_key not in self._guide_states:
-                prev_state = self._guide_states[hash(tuple(gen_ids[:-1].tolist()))]
-                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1].item())
+                prev_state = self._guide_states[hash(tuple(self.tensor_adapter.to_list(gen_ids[:-1])))]
+                curr_state = self.guide.get_next_state(prev_state, self.tensor_adapter.to_scalar(gen_ids[-1]))
                 self._guide_states[curr_state_key] = curr_state
 
             sequence_states.append(self._guide_states[curr_state_key])
@@ -110,63 +111,64 @@ class GuideLogitsProcessor(OutlinesLogitsProcessor):
             allowed_tokens = self.guide.get_next_instruction(guide_state).tokens
             allowed_tokens_batch.append(allowed_tokens)
             batch_indices.append(
-                torch.full_like(allowed_tokens, i)
+                self.tensor_adapter.full_like(allowed_tokens, i)
             )  # Store batch index for each allowed token
 
-        allowed_tokens_concat = torch.cat(allowed_tokens_batch).to(logits.device)
-        batch_indices_concat = torch.cat(batch_indices).to(logits.device)
+        device = self.tensor_adapter.get_device(logits)
+        allowed_tokens_concat = self.tensor_adapter.to_device(
+            self.tensor_adapter.concatenate(allowed_tokens_batch),
+            device
+        )
+        batch_indices_concat = self.tensor_adapter.to_device(
+            self.tensor_adapter.concatenate(batch_indices),
+            device
+        )
 
-        mask = torch.ones_like(logits, dtype=torch.bool)
+        mask = self.tensor_adapter.boolean_ones_like(logits)
         mask[batch_indices_concat, allowed_tokens_concat] = False
-        logits.masked_fill_(mask, float("-inf"))
+        logits = self.tensor_adapter.apply_mask(logits, mask, float("-inf"))
 
         return logits
 
     def copy(self) -> "GuideLogitsProcessor":
         """Return a copy of the logits processor."""
-        return GuideLogitsProcessor(tokenizer=self.tokenizer, guide=self.guide.copy())
+        return GuideLogitsProcessor(
+            tokenizer=self.tokenizer,
+            guide=self.guide.copy(),
+            tensor_library_name=self.tensor_adapter.library_name
+        )
 
 
 class RegexLogitsProcessor(GuideLogitsProcessor):
-    """Bias generation based on a regular expression.
-
-    Attributes
-    ----------
-    tokenizer
-        The tokenizer used to convert tokens to ids.
-    guide
-        The `outlines.fsm.RegexGuide. which is used to bias the logits.
-    """
-
-    def __init__(self, regex_string: str, tokenizer: "Tokenizer"):
+    """Bias generation based on a regular expression."""
+    def __init__(
+        self,
+        regex_string: str,
+        tokenizer: "Tokenizer",
+        tensor_library_name: str,
+    ):
         """Compile the RegexGuide that drives the regex-guided generation.
 
         Parameters
         ----------
         regex_string
-            A string that represents a regular expression
+            A string that represents a regular expression.
         tokenizer
-            An Outlines tokenizer
+            An Outlines tokenizer.
+        tensor_library_name
+            The name of the library to use to manipulate the tensors.
         """
         guide = RegexGuide.from_regex(regex_string, tokenizer)
-        super().__init__(tokenizer=tokenizer, guide=guide)
+        super().__init__(tokenizer=tokenizer, guide=guide, tensor_library_name=tensor_library_name)
 
 
 class JSONLogitsProcessor(RegexLogitsProcessor):
-    """Bias generation based on a JSON schema.
-
-    Attributes
-    ----------
-    tokenizer
-        The tokenizer used to convert tokens to ids.
-    guide
-        The `outlines.fsm.RegexGuide. which is used to bias the logits.
-    """
-
+    """Bias generation based on a JSON schema."""
     def __init__(
         self,
         schema: Union[dict, Type[BaseModel], str],
         tokenizer: "Tokenizer",
+        tensor_library_name: str,
         whitespace_pattern: Optional[str] = None,
     ):
         """Compile the Guide that drives the JSON-guided generation.
@@ -177,14 +179,16 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
             A JSON schema that encodes the structure we want the model to generate.
         tokenizer
             The tokenizer used to convert tokens to ids.
+        tensor_library_name
+            The name of the library to use to manipulate the tensors.
         whitespace_pattern
             Pattern to use for JSON syntactic whitespace (doesn't impact string
             literals). For example, to allow only a single space or newline with
-            `whitespace_pattern=r"[\n ]?"`
+            `whitespace_pattern=r"[\n ]?"`.
         """
         schema_str = JsonSchema(schema).schema
         regex_string = build_regex_from_schema(schema_str, whitespace_pattern)
-        super().__init__(regex_string=regex_string, tokenizer=tokenizer)
+        super().__init__(regex_string=regex_string, tokenizer=tokenizer, tensor_library_name=tensor_library_name)
 
 
 class CFGLogitsProcessor(GuideLogitsProcessor):
@@ -200,7 +204,7 @@ class CFGLogitsProcessor(GuideLogitsProcessor):
 
     guide: CFGGuide
 
-    def __init__(self, cfg_str: str, tokenizer: "Tokenizer"):
+    def __init__(self, cfg_str: str, tokenizer: "Tokenizer", tensor_library_name: str):
         """Compile the CFGGuide that drives the CFG-guided generation.
 
         Parameters
@@ -211,11 +215,11 @@ class CFGLogitsProcessor(GuideLogitsProcessor):
             The tokenizer used to convert tokens to ids.
         """
         cfg_guide = CFGGuide(cfg_string=cfg_str, tokenizer=tokenizer)
-        super().__init__(tokenizer=tokenizer, guide=cfg_guide)
+        super().__init__(tokenizer=tokenizer, guide=cfg_guide, tensor_library_name=tensor_library_name)
 
     def process_logits(
-        self, input_ids: torch.LongTensor, logits: torch.Tensor
-    ) -> torch.Tensor:
+        self, input_ids, logits
+    ):
         """Same behavior as GuideLogitsProcessor, but uses rejection sampling"""
         if self._seq_start_idx is None:
             self._seq_start_idx = len(input_ids[0])
@@ -224,20 +228,20 @@ class CFGLogitsProcessor(GuideLogitsProcessor):
 
         for seq_ids in input_ids:
             gen_ids = seq_ids[self._seq_start_idx :]
-            curr_state_key = hash(tuple(gen_ids.tolist()))
+            curr_state_key = hash(tuple(self.tensor_adapter.to_list(gen_ids)))
 
-            if curr_state_key not in self._guide_states:
-                prev_state = self._guide_states[hash(tuple(gen_ids[:-1].tolist()))]
-                curr_state = self.guide.get_next_state(prev_state, gen_ids[-1].item())
+            if curr_state_key not in self._guide_states: # pragma: no cover
+                prev_state = self._guide_states[hash(tuple(self.tensor_adapter.to_list(gen_ids[:-1])))]
+                curr_state = self.guide.get_next_state(prev_state, self.tensor_adapter.to_scalar(gen_ids[-1]))
                 self._guide_states[curr_state_key] = curr_state
 
             sequence_states.append(self._guide_states[curr_state_key])
 
-        mask = torch.full_like(logits, -math.inf)
+        mask = self.tensor_adapter.full_like(logits, -math.inf)
         for i, guide_state in enumerate(sequence_states):
             first_legal_token = next(
                 self.guide.iter_valid_token_ids(
-                    guide_state, torch.argsort(logits[i], descending=True)
+                    guide_state, self.tensor_adapter.argsort_descending(logits[i])
                 )
             )
             mask[i, [first_legal_token]] = logits[i, [first_legal_token]]

--- a/outlines/processors/tensor_adapters/__init__.py
+++ b/outlines/processors/tensor_adapters/__init__.py
@@ -1,0 +1,24 @@
+from typing import Union
+
+from .jax import JAXTensorAdapter
+from .mlx import MLXTensorAdapter
+from .numpy import NumpyTensorAdapter
+from .tensorflow import TensorFlowTensorAdapter
+from .torch import TorchTensorAdapter
+
+
+tensor_adapters = {
+    "jax": JAXTensorAdapter,
+    "mlx": MLXTensorAdapter,
+    "numpy": NumpyTensorAdapter,
+    "torch": TorchTensorAdapter,
+    "tensorflow": TensorFlowTensorAdapter,
+}
+
+TensorAdapterImplementation = Union[
+    JAXTensorAdapter,
+    MLXTensorAdapter,
+    NumpyTensorAdapter,
+    TorchTensorAdapter,
+    TensorFlowTensorAdapter,
+]

--- a/outlines/processors/tensor_adapters/base.py
+++ b/outlines/processors/tensor_adapters/base.py
@@ -1,0 +1,72 @@
+from abc import ABC, abstractmethod
+
+
+class TensorAdapter(ABC):
+    """Abstract base class for tensor adapters.
+
+    This class defines the interface for tensor adapters that are used to
+    manipulate tensors in different libraries. Concrete implementations of
+    this class should provide specific implementations for each method as
+    well as providing a library_name attribute.
+    """
+    library_name: str
+
+    @abstractmethod
+    def shape(self, tensor):
+        """Get the shape of the tensor"""
+        ...
+
+    @abstractmethod
+    def unsqueeze(self, tensor):
+        """Add a dimension to the tensor at the specified position"""
+        ...
+
+    @abstractmethod
+    def squeeze(self, tensor):
+        """Remove a dimension from the tensor at the specified position"""
+        ...
+
+    @abstractmethod
+    def to_list(self, tensor):
+        """Convert the tensor to a list"""
+        ...
+
+    @abstractmethod
+    def to_scalar(self, tensor):
+        """Convert the tensor to a scalar"""
+        ...
+
+    @abstractmethod
+    def full_like(self, tensor, fill_value):
+        """Create a tensor with the same shape as the input tensor filled with a scalar value"""
+        ...
+
+    @abstractmethod
+    def concatenate(self, tensors):
+        """Concatenate a list of tensors along a specified dimension"""
+        ...
+
+    @abstractmethod
+    def get_device(self, tensor):
+        """Get the device of the tensor"""
+        ...
+
+    @abstractmethod
+    def to_device(self, tensor, device):
+        """Move the tensor to a specified device"""
+        ...
+
+    @abstractmethod
+    def boolean_ones_like(self, tensor):
+        """Create a boolean ones tensor with the same shape as the input tensor"""
+        ...
+
+    @abstractmethod
+    def apply_mask(self, tensor, mask, value):
+        """Fill the elements of the tensor where the mask is True with the specified value"""
+        ...
+
+    @abstractmethod
+    def argsort_descending(self, tensor):
+        """Return the indices that would sort the tensor in descending order"""
+        ...

--- a/outlines/processors/tensor_adapters/jax.py
+++ b/outlines/processors/tensor_adapters/jax.py
@@ -1,0 +1,48 @@
+from outlines.processors.tensor_adapters.base import TensorAdapter
+
+
+class JAXTensorAdapter(TensorAdapter):
+    library_name = "jax"
+
+    def __init__(self):
+        import jax
+
+        self.jax = jax
+
+    def shape(self, tensor):
+        return tensor.shape
+
+    def unsqueeze(self, tensor):
+        return self.jax.numpy.expand_dims(tensor, axis=0)
+
+    def squeeze(self, tensor):
+        return self.jax.numpy.squeeze(tensor, axis=0)
+
+    def to_list(self, tensor):
+        return tensor.tolist()
+
+    def to_scalar(self, tensor):
+        return tensor.item()
+
+    def full_like(self, tensor, fill_value):
+        return self.jax.numpy.full_like(tensor, fill_value)
+
+    def concatenate(self, tensors):
+        return self.jax.numpy.concatenate(tensors, axis=0)
+
+    def to_device(self, tensor, device):
+        return tensor
+
+    def get_device(self, tensor):
+        return None
+
+    def boolean_ones_like(self, tensor):
+        return self.jax.numpy.ones_like(tensor, dtype=bool)
+
+    def apply_mask(self, tensor, mask, value):
+        result = tensor.copy()
+        result = result.at[mask].set(value)
+        return result
+
+    def argsort_descending(self, tensor):
+        return self.jax.numpy.argsort(-tensor)

--- a/outlines/processors/tensor_adapters/mlx.py
+++ b/outlines/processors/tensor_adapters/mlx.py
@@ -1,0 +1,50 @@
+from outlines.processors.tensor_adapters.base import TensorAdapter
+
+
+class MLXTensorAdapter(TensorAdapter):
+    library_name = "mlx"
+
+    def __init__(self):
+        import mlx.core
+
+        self.mlx = mlx.core
+
+    def shape(self, tensor):
+        return tensor.shape
+
+    def unsqueeze(self, tensor):
+        return self.mlx.expand_dims(tensor, 0)
+
+    def squeeze(self, tensor):
+        if tensor.shape[0] == 1:
+            return tensor[0]
+        return tensor
+
+    def to_list(self, tensor):
+        return tensor.tolist()
+
+    def to_scalar(self, tensor):
+        return tensor.item()
+
+    def full_like(self, tensor, fill_value):
+        return self.mlx.full(tensor.shape, fill_value, dtype=tensor.dtype)
+
+    def concatenate(self, tensors):
+        return self.mlx.concat(tensors, axis=0)
+
+    def get_device(self, tensor):
+        return None
+
+    def to_device(self, tensor, device):
+        return tensor
+
+    def boolean_ones_like(self, tensor):
+        return self.mlx.ones(tensor.shape, dtype=self.mlx.bool_)
+
+    def apply_mask(self, tensor, mask, value):
+        result = tensor.astype(tensor.dtype)
+        result = self.mlx.where(mask, self.mlx.array(value), result)
+        return result
+
+    def argsort_descending(self, tensor):
+        return self.mlx.argsort(-tensor)

--- a/outlines/processors/tensor_adapters/numpy.py
+++ b/outlines/processors/tensor_adapters/numpy.py
@@ -1,0 +1,48 @@
+from outlines.processors.tensor_adapters.base import TensorAdapter
+
+
+class NumpyTensorAdapter(TensorAdapter):
+    library_name = "numpy"
+
+    def __init__(self):
+        import numpy
+
+        self.numpy = numpy
+
+    def shape(self, tensor):
+        return tensor.shape
+
+    def unsqueeze(self, tensor):
+        return self.numpy.expand_dims(tensor, axis=0)
+
+    def squeeze(self, tensor):
+        return self.numpy.squeeze(tensor, axis=0)
+
+    def to_list(self, tensor):
+        return tensor.tolist()
+
+    def to_scalar(self, tensor):
+        return tensor.item()
+
+    def full_like(self, tensor, fill_value):
+        return self.numpy.full_like(tensor, fill_value)
+
+    def concatenate(self, tensors):
+        return self.numpy.concatenate(tensors, axis=0)
+
+    def get_device(self, tensor):
+        return None
+
+    def to_device(self, tensor, device):
+        return tensor
+
+    def boolean_ones_like(self, tensor):
+        return self.numpy.ones_like(tensor, dtype=bool)
+
+    def apply_mask(self, tensor, mask, value):
+        result = tensor.copy()
+        result[mask] = value
+        return result
+
+    def argsort_descending(self, tensor):
+        return self.numpy.argsort(-tensor)

--- a/outlines/processors/tensor_adapters/tensorflow.py
+++ b/outlines/processors/tensor_adapters/tensorflow.py
@@ -1,0 +1,48 @@
+from outlines.processors.tensor_adapters.base import TensorAdapter
+
+
+class TensorFlowTensorAdapter(TensorAdapter):
+    library_name = "tensorflow"
+
+    def __init__(self):
+        import tensorflow as tf
+
+        self.tf = tf
+
+    def shape(self, tensor):
+        return tensor.shape
+
+    def unsqueeze(self, tensor):
+        return self.tf.expand_dims(tensor, axis=0)
+
+    def squeeze(self, tensor):
+        return self.tf.squeeze(tensor, axis=0)
+
+    def to_list(self, tensor):
+        return tensor.numpy().tolist()
+
+    def to_scalar(self, tensor):
+        return tensor.numpy().item()
+
+    def full_like(self, tensor, fill_value):
+        return self.tf.fill(self.tf.shape(tensor), fill_value)
+
+    def concatenate(self, tensors):
+        return self.tf.concat(tensors, axis=0)
+
+    def get_device(self, tensor):
+        return tensor.device
+
+    def to_device(self, tensor, device):
+        # TensorFlow handles device placement differently
+        with self.tf.device(device):
+            return self.tf.identity(tensor)
+
+    def boolean_ones_like(self, tensor):
+        return self.tf.ones_like(tensor, dtype=self.tf.bool)
+
+    def apply_mask(self, tensor, mask, value):
+        return self.tf.where(mask, self.tf.constant(value, dtype=tensor.dtype), tensor)
+
+    def argsort_descending(self, tensor):
+        return self.tf.argsort(tensor, direction='DESCENDING')

--- a/outlines/processors/tensor_adapters/torch.py
+++ b/outlines/processors/tensor_adapters/torch.py
@@ -1,0 +1,46 @@
+from outlines.processors.tensor_adapters.base import TensorAdapter
+
+
+class TorchTensorAdapter(TensorAdapter):
+    library_name = "torch"
+
+    def __init__(self):
+        import torch
+
+        self.torch = torch
+
+    def shape(self, tensor):
+        return tensor.shape
+
+    def unsqueeze(self, tensor):
+        return tensor.unsqueeze(0)
+
+    def squeeze(self, tensor):
+        return tensor.squeeze(0)
+
+    def to_list(self, tensor):
+        return tensor.tolist()
+
+    def to_scalar(self, tensor):
+        return tensor.item()
+
+    def full_like(self, tensor, fill_value):
+        return self.torch.full_like(tensor, fill_value)
+
+    def concatenate(self, tensors):
+        return self.torch.cat(tensors, dim=0)
+
+    def get_device(self, tensor):
+        return tensor.device
+
+    def to_device(self, tensor, device):
+        return tensor.to(device)
+
+    def boolean_ones_like(self, tensor):
+        return self.torch.ones_like(tensor, dtype=self.torch.bool)
+
+    def apply_mask(self, tensor, mask, value):
+        return self.torch.masked_fill(tensor, mask, value)
+
+    def argsort_descending(self, tensor):
+        return self.torch.argsort(tensor, descending=True)

--- a/outlines/serve/serve.py
+++ b/outlines/serve/serve.py
@@ -70,10 +70,11 @@ async def generate(request: Request) -> Response:
 
     json_schema = request_dict.pop("schema", None)
     regex_string = request_dict.pop("regex", None)
+    tensor_library_name = request_dict.pop("tensor_library_name", "torch")
     if json_schema is not None:
-        logits_processors = [JSONLogitsProcessor(json_schema, tokenizer)]
+        logits_processors = [JSONLogitsProcessor(json_schema, tokenizer, tensor_library_name)]
     elif regex_string is not None:
-        logits_processors = [RegexLogitsProcessor(regex_string, tokenizer)]
+        logits_processors = [RegexLogitsProcessor(regex_string, tokenizer, tensor_library_name)]
     else:
         logits_processors = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
    "jinja2",
    "lark",
    "nest_asyncio",
-   "numpy",
    "cloudpickle",
    "diskcache",
    "pydantic>=2.0",
@@ -40,7 +39,6 @@ dependencies = [
    "typing_extensions",
    "iso3166",
    "airportsdata",
-   "torch",
    "outlines_core==0.1.26",
    "genson",
 ]
@@ -68,6 +66,11 @@ test = [
     "transformers",
     "pillow",
     "jax",
+    "flax",
+    "numpy",
+    "torch",
+    "tensorflow",
+    "tf-keras",
     "ollama",
     "dottxt",
     "sentencepiece",
@@ -107,6 +110,7 @@ filterwarnings = [
     "ignore::FutureWarning:huggingface_hub.*",
     "ignore::UserWarning",
     "ignore::DeprecationWarning:pyairports.*",
+    "ignore::DeprecationWarning:jax.*",
 ]
 
 [tool.mypy]
@@ -152,6 +156,10 @@ module = [
     "genson",
     "ollama.*",
     "dottxt.*",
+    "tensorflow",
+    "tensorflow.*",
+    "tf-keras",
+    "tf-keras.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ filterwarnings = [
     "ignore::UserWarning",
     "ignore::DeprecationWarning:pyairports.*",
     "ignore::DeprecationWarning:jax.*",
+    "ignore::DeprecationWarning:flax.*",
 ]
 
 [tool.mypy]
@@ -167,6 +168,10 @@ ignore_missing_imports = true
 omit = [
     "outlines/_version.py",
     "tests/*",
+    "outlines/models/mlxlm.py",
+    "outlines/models/vllm.py",
+    "outlines/processors/tensor_adapters/mlx.py",
+    "outlines/serve/serve.py",
 ]
 branch = true
 relative_files = true

--- a/tests/models/test_llamacpp.py
+++ b/tests/models/test_llamacpp.py
@@ -5,13 +5,18 @@ import pytest
 from llama_cpp import Llama
 from pydantic import BaseModel
 
-from outlines.models import LlamaCpp
+from outlines.models.llamacpp import (
+    LlamaCpp,
+    LlamaCppTokenizer,
+    LlamaCppTypeAdapter,
+    from_llamacpp
+)
 from outlines.processors import RegexLogitsProcessor
 from outlines.types.dsl import Regex, python_types_to_terms, to_regex
 
 
 def test_load_model():
-    model = LlamaCpp(
+    model = from_llamacpp(
         Llama.from_pretrained(
             repo_id="M4-ai/TinyMistral-248M-v2-Instruct-GGUF",
             filename="TinyMistral-248M-v2-Instruct.Q4_K_M.gguf",
@@ -20,6 +25,9 @@ def test_load_model():
 
     assert isinstance(model, LlamaCpp)
     assert isinstance(model.model, Llama)
+    assert isinstance(model.tokenizer, LlamaCppTokenizer)
+    assert isinstance(model.type_adapter, LlamaCppTypeAdapter)
+    assert model.tensor_library_name == "numpy"
 
 
 @pytest.fixture(scope="session")
@@ -39,7 +47,7 @@ def test_llamacpp_simple(model):
 
 def test_llamacpp_regex(model):
     regex_str = Regex(r"[0-9]").pattern
-    logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer)
+    logits_processor = RegexLogitsProcessor(regex_str, model.tokenizer, model.tensor_library_name)
     result = model.generate("Respond with one word. Not more.", logits_processor)
     assert isinstance(result, str)
 

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -6,7 +6,11 @@ from pydantic import BaseModel
 import transformers
 
 import outlines
-from outlines.models.transformers import Transformers
+from outlines.models.transformers import (
+    Transformers,
+    TransformerTokenizer,
+    TransformersTypeAdapter,
+)
 from outlines.types import Regex
 
 TEST_MODEL = "erwanf/gpt2-mini"
@@ -20,14 +24,31 @@ def test_transformers_instantiate_simple():
         transformers.AutoTokenizer.from_pretrained(TEST_MODEL),
     )
     assert isinstance(model, Transformers)
+    assert isinstance(model.tokenizer, TransformerTokenizer)
+    assert isinstance(model.type_adapter, TransformersTypeAdapter)
+    assert model.tensor_library_name == "torch"
 
 
-def test_transformers_instantiate_other_model_class():
+def test_transformers_instantiate_flax_model():
     model = outlines.from_transformers(
-        transformers.AutoModelForSeq2SeqLM.from_pretrained(TEST_MODEL_SEQ2SEQ),
+        transformers.FlaxAutoModelForCausalLM.from_pretrained(TEST_MODEL),
         transformers.AutoTokenizer.from_pretrained(TEST_MODEL),
     )
     assert isinstance(model, Transformers)
+    assert isinstance(model.tokenizer, TransformerTokenizer)
+    assert isinstance(model.type_adapter, TransformersTypeAdapter)
+    assert model.tensor_library_name == "jax"
+
+
+def test_transformers_instantiate_tensorflow_model():
+    model = outlines.from_transformers(
+        transformers.TFAutoModelForCausalLM.from_pretrained(TEST_MODEL),
+        transformers.AutoTokenizer.from_pretrained(TEST_MODEL),
+    )
+    assert isinstance(model, Transformers)
+    assert isinstance(model.tokenizer, TransformerTokenizer)
+    assert isinstance(model.type_adapter, TransformersTypeAdapter)
+    assert model.tensor_library_name == "tensorflow"
 
 
 def test_transformers_instantiate_mamba():

--- a/tests/models/test_transformers_multimodal.py
+++ b/tests/models/test_transformers_multimodal.py
@@ -9,19 +9,19 @@ import pytest
 from PIL import Image
 from pydantic import BaseModel
 from transformers import (
-    Blip2ForConditionalGeneration,
-    CLIPModel,
-    CLIPProcessor,
     LlavaForConditionalGeneration,
     AutoProcessor,
 )
 
 import outlines
-from outlines.models.transformers import TransformersMultiModal
+from outlines.models.transformers import (
+    TransformersMultiModal,
+    TransformerTokenizer,
+    TransformersMultiModalTypeAdapter,
+)
 from outlines.types import Regex
 
 TEST_MODEL = "trl-internal-testing/tiny-LlavaForConditionalGeneration"
-TEST_CLIP_MODEL = "openai/clip-vit-base-patch32"
 IMAGE_URLS = [
     "https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg",
     "https://upload.wikimedia.org/wikipedia/commons/7/71/2010-kodiak-bear-1.jpg",
@@ -47,10 +47,13 @@ def model():
 
 def test_transformers_vision_instantiate_simple():
     model = outlines.from_transformers(
-        Blip2ForConditionalGeneration.from_pretrained(TEST_MODEL),
+        LlavaForConditionalGeneration.from_pretrained(TEST_MODEL),
         AutoProcessor.from_pretrained(TEST_MODEL),
     )
     assert isinstance(model, TransformersMultiModal)
+    assert isinstance(model.tokenizer, TransformerTokenizer)
+    assert isinstance(model.type_adapter, TransformersMultiModalTypeAdapter)
+    assert model.tensor_library_name == "torch"
 
 
 def test_transformers_vision_simple(model, images):

--- a/tests/models/test_vllm.py
+++ b/tests/models/test_vllm.py
@@ -7,20 +7,35 @@ from pydantic import BaseModel
 
 try:
     from vllm import LLM, SamplingParams
+    HAS_VLLM = True
 except ImportError:
-    pass
+    HAS_VLLM = False
 
 import outlines
-from outlines.models.vllm import VLLM
+from outlines.models.vllm import (
+    VLLM,
+    VLLMTypeAdapter,
+    from_vllm
+)
 from outlines.types import Regex
 
 
 TEST_MODEL = "erwanf/gpt2-mini"
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
+    not HAS_VLLM,
     reason="vLLM models can only be run on GPU."
 )
+
+
+def test_vllm_model_initialization():
+    model = from_vllm(LLM(TEST_MODEL))
+    assert isinstance(model, VLLM)
+    assert isinstance(model.model, LLM)
+    assert hasattr(model, "tokenizer")
+    assert isinstance(model.type_adapter, VLLMTypeAdapter)
+    assert model.tensor_library_name == "torch"
+
 
 @pytest.fixture(scope="session")
 def model(tmp_path_factory):

--- a/tests/processors/test_base_processor.py
+++ b/tests/processors/test_base_processor.py
@@ -7,81 +7,96 @@ import torch
 
 from outlines.processors.base_logits_processor import OutlinesLogitsProcessor
 
-arrays = {
-    "list": [[1.0, 2.0], [3.0, 4.0]],
-    "np": np.array([[1, 2], [3, 4]], dtype=np.float32),
-    "jax": jnp.array([[1, 2], [3, 4]], dtype=jnp.float32),
-    "torch": torch.tensor([[1, 2], [3, 4]], dtype=torch.float32),
-}
-
 try:
     import mlx.core as mx
-
-    arrays["mlx"] = mx.array([[1, 2], [3, 4]], dtype=mx.float32)
-    arrays["mlx_bfloat16"] = mx.array([[1, 2], [3, 4]], dtype=mx.bfloat16)
+    HAS_MLX = True
 except ImportError:
-    pass
-
-try:
-    import jax.numpy as jnp
-
-    arrays["jax"] = jnp.array([[1, 2], [3, 4]], dtype=jnp.float32)
-except ImportError:
-    pass
+    HAS_MLX = False
 
 
-# Mock implementation of the abstract class for testing
+libraries = ["numpy", "torch", "jax"]
+if HAS_MLX:
+    libraries.append("mlx")
+
+# we check the accepted shapes:
+# - both 1D
+# - both 2D
+# - input_ids 1D and logits 2D with a single sequence
+# we raise an error if the shapes are not accepted:
+# - input_ids 2D and logits 1D
+# - input_ids 1D and logits 2D, but with multiple sequences
+# - both 3D
+arrays = {
+    "numpy": [
+        (np.array([1, 2], dtype=np.float32), np.array([1, 2], dtype=np.int32), None),
+        (np.array([[1, 2], [3, 4]], dtype=np.float32), np.array([[1, 2], [3, 4]], dtype=np.int32), None),
+        (np.array([1, 2], dtype=np.float32), np.array([[1, 2]], dtype=np.int32), None),
+        (np.array([[1, 2]], dtype=np.float32), np.array([1, 2], dtype=np.int32), AssertionError),
+        (np.array([1, 2], dtype=np.float32), np.array([[1, 2], [3, 4]], dtype=np.int32), AssertionError),
+        (np.array([[[1, 2]]], dtype=np.float32), np.array([[[1, 2]]], dtype=np.int32), ValueError),
+    ],
+    "torch": [
+        (torch.tensor([1, 2], dtype=torch.float32), torch.tensor([1, 2], dtype=torch.int32), None),
+        (torch.tensor([[1, 2], [3, 4]], dtype=torch.float32), torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), None),
+        (torch.tensor([1, 2], dtype=torch.float32), torch.tensor([[1, 2]], dtype=torch.int32), None),
+        (torch.tensor([[1, 2]], dtype=torch.float32), torch.tensor([1, 2], dtype=torch.int32), AssertionError),
+        (torch.tensor([1, 2], dtype=torch.float32), torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), AssertionError),
+        (torch.tensor([[[1, 2]]], dtype=torch.float32), torch.tensor([[[1, 2]]], dtype=torch.int32), ValueError),
+    ],
+    "jax": [
+        (jnp.array([1, 2], dtype=jnp.float32), jnp.array([1, 2], dtype=jnp.int32), None),
+        (jnp.array([[1, 2], [3, 4]], dtype=jnp.float32), jnp.array([[1, 2], [3, 4]], dtype=jnp.int32), None),
+        (jnp.array([1, 2], dtype=jnp.float32), jnp.array([[1, 2]], dtype=jnp.int32), None),
+        (jnp.array([[1, 2]], dtype=jnp.float32), jnp.array([1, 2], dtype=jnp.int32), AssertionError),
+        (jnp.array([1, 2], dtype=jnp.float32), jnp.array([[1, 2], [3, 4]], dtype=jnp.int32), AssertionError),
+        (jnp.array([[[1, 2]]], dtype=jnp.float32), jnp.array([[[1, 2]]], dtype=jnp.int32), ValueError),
+    ],
+}
+if HAS_MLX:
+    arrays["mlx"] = [
+        (mx.array([1, 2], dtype=mx.float32), mx.array([1, 2], dtype=mx.int32), None),
+        (mx.array([[1, 2], [3, 4]], dtype=mx.float32), mx.array([[1, 2], [3, 4]], dtype=mx.int32), None),
+        (mx.array([1, 2], dtype=mx.float32), mx.array([[1, 2]], dtype=mx.int32), None),
+        (mx.array([[1, 2]], dtype=mx.float32), mx.array([1, 2], dtype=mx.int32), AssertionError),
+        (mx.array([1, 2], dtype=mx.float32), mx.array([[1, 2], [3, 4]], dtype=mx.int32), AssertionError),
+        (mx.array([[[1, 2]]], dtype=mx.float32), mx.array([[[1, 2]]], dtype=mx.int32), ValueError),
+    ]
+
 class MockLogitsProcessor(OutlinesLogitsProcessor):
-    def process_logits(
-        self, input_ids: List[List[int]], logits: torch.Tensor
-    ) -> torch.Tensor:
-        # For testing purposes, let's just return logits multiplied by 2
-        return logits * 2
+    def process_logits(self, input_ids, logits):
+        # check that input_ids and logits received are 2D tensors
+        assert len(self.tensor_adapter.shape(input_ids)) == 2
+        assert len(self.tensor_adapter.shape(logits)) == 2
+        return logits
 
 
-@pytest.fixture
-def processor():
-    """Fixture for creating an instance of the MockLogitsProcessor."""
-    return MockLogitsProcessor()
+@pytest.mark.parametrize("library", libraries)
+def test_base_logits_processor_init(library):
+    processor = MockLogitsProcessor(library)
+    assert processor.tensor_adapter is not None
+    with pytest.raises(NotImplementedError):
+        processor = MockLogitsProcessor("foo")
 
 
-@pytest.mark.parametrize("array_type", arrays.keys())
-def test_to_torch(array_type, processor):
-    data = arrays[array_type]
-    torch_tensor = processor._to_torch(data)
-    assert isinstance(torch_tensor, torch.Tensor)
-    assert torch.allclose(
-        torch_tensor.cpu(), torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)
-    )
+@pytest.mark.parametrize("library", libraries)
+def test_base_logits_processor_call(library):
+    processor = MockLogitsProcessor(library)
+    input_values = arrays[library]
+    for input_value in input_values:
+        input_ids, logits, expected_error = input_value
+        if expected_error is not None:
+            with pytest.raises(expected_error):
+                processor(input_ids, logits)
+        else:
+            original_shape = processor.tensor_adapter.shape(logits)
+            processed_logits = processor(input_ids, logits)
+            # we check that the shape of logits is preserved
+            assert processor.tensor_adapter.shape(processed_logits) == original_shape
 
 
-@pytest.mark.parametrize("array_type", arrays.keys())
-def test_from_torch(array_type, processor):
-    torch_tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)
-    data = processor._from_torch(torch_tensor, type(arrays[array_type]))
-    assert isinstance(data, type(arrays[array_type]))
-    if array_type == "mlx_bfloat16":
-        # For bfloat16, we expect the output to be float32 due to the conversion
-        assert data.dtype == mx.float32
-        assert np.allclose(np.array(data), np.array([[1, 2], [3, 4]], dtype=np.float32))
-    else:
-        assert np.allclose(data, arrays[array_type])
-
-
-@pytest.mark.parametrize("array_type", arrays.keys())
-def test_call(array_type, processor):
-    input_ids = arrays[array_type]
-    logits = arrays[array_type]
-    processed_logits = processor(input_ids, logits)
-
-    assert isinstance(processed_logits, type(arrays[array_type]))
-
-    # Convert to numpy array for comparison, handling PyTorch tensors properly
-    if array_type == "torch":
-        expected = np.array([[2.0, 4.0], [6.0, 8.0]], dtype=np.float32)
-        actual = processed_logits.detach().cpu().numpy()
-        assert np.allclose(actual, expected)
-    else:
-        assert np.allclose(
-            np.array(processed_logits), np.array([[2.0, 4.0], [6.0, 8.0]], dtype=np.float32)
-        )
+@pytest.mark.parametrize("library", libraries)
+def test_base_logits_processor_init_library_name(library):
+    processor = MockLogitsProcessor(library)
+    assert processor.tensor_adapter is not None
+    with pytest.raises(NotImplementedError):
+        processor = MockLogitsProcessor("foo")

--- a/tests/processors/test_guide.py
+++ b/tests/processors/test_guide.py
@@ -202,6 +202,7 @@ def test_regex_guide_caching():
     assert caching._caching_enabled
 
     cache = caching.get_cache()
+    cache.clear()
     _, _ = cache.stats(enable=True, reset=True) # (hits, misses)
 
     regex = r"[0-9]{3}"
@@ -221,7 +222,7 @@ def test_regex_guide_caching():
             *mlx_lm.load("mlx-community/SmolLM-135M-Instruct-4bit")
         ))
     if HAS_VLLM:
-        models.append(outlines.from_vllm(vllm.LLM("erwanf/gpt2-mini")))
+        models.append(outlines.from_vllm(vllm.LLM("TinyLlama/TinyLlama-1.1B-Chat-v1.0")))
 
     for i, model in enumerate(models):
         # First call for each model should be a miss

--- a/tests/processors/test_structured.py
+++ b/tests/processors/test_structured.py
@@ -1,0 +1,134 @@
+import pytest
+from typing import Dict
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+import outlines
+from outlines.processors.guide import RegexGuide
+from outlines.processors.structured import (
+    GuideLogitsProcessor,
+    RegexLogitsProcessor,
+    JSONLogitsProcessor,
+    CFGLogitsProcessor,
+)
+
+
+arithmetic_grammar = """
+?start: sum
+
+?sum: product
+| sum "+" product   -> add
+| sum "-" product   -> sub
+
+?product: atom
+| product "*" atom  -> mul
+| product "/" atom  -> div
+
+?atom: NUMBER           -> number
+| "-" atom         -> neg
+| "(" sum ")"
+
+%import common.NUMBER
+%import common.WS_INLINE
+
+%ignore WS_INLINE
+"""
+
+@pytest.fixture
+def tokenizer():
+    model = outlines.from_transformers(
+        AutoModelForCausalLM.from_pretrained("erwanf/gpt2-mini"),
+        AutoTokenizer.from_pretrained("erwanf/gpt2-mini"),
+    )
+    return model.tokenizer
+
+
+def test_structured_init_guide_logits_processor(tokenizer):
+    guide = RegexGuide.from_regex(r"[a-z]+", tokenizer)
+    processor = GuideLogitsProcessor(
+        tokenizer=tokenizer,
+        guide=guide,
+        tensor_library_name="torch",
+    )
+    assert isinstance(processor, GuideLogitsProcessor)
+    assert processor.tokenizer is tokenizer
+    assert processor.guide is guide
+    assert processor.tensor_adapter.library_name == "torch"
+
+
+def test_structured_init_guide_logits_processor_copy(tokenizer):
+    guide = RegexGuide.from_regex(r"[a-z]+", tokenizer)
+    processor = GuideLogitsProcessor(
+        tokenizer=tokenizer,
+        guide=guide,
+        tensor_library_name="torch",
+    )
+    processor_copy = processor.copy()
+    assert processor_copy is not processor
+    assert processor_copy.tokenizer is tokenizer
+    assert processor_copy.guide is guide
+    assert processor_copy.tensor_adapter.library_name == "torch"
+
+
+def test_structured_guide_logits_processor_call(tokenizer):
+    guide = RegexGuide.from_regex(r"[a-z]+", tokenizer)
+    processor = GuideLogitsProcessor(
+        tokenizer=tokenizer,
+        guide=guide,
+        tensor_library_name="torch",
+    )
+    vocab_token_ids = list(tokenizer.vocabulary.values())
+    logits = torch.randn(1, len(vocab_token_ids))
+    input_ids = torch.randint(0, len(vocab_token_ids), (1, 10))
+    output = processor(input_ids, logits)
+    assert output.shape == (1, len(vocab_token_ids))
+
+
+def test_structured_init_json_logits_processor(tokenizer):
+    processor = JSONLogitsProcessor(
+        schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        tokenizer=tokenizer,
+        tensor_library_name="torch",
+    )
+    assert isinstance(processor, JSONLogitsProcessor)
+    assert processor.tokenizer is tokenizer
+    assert processor.guide is not None
+    assert processor.tensor_adapter.library_name == "torch"
+
+
+def test_structured_init_regex_logits_processor(tokenizer):
+    processor = RegexLogitsProcessor(
+        regex_string=r"[a-z]+",
+        tokenizer=tokenizer,
+        tensor_library_name="torch",
+    )
+    assert isinstance(processor, RegexLogitsProcessor)
+    assert processor.tokenizer is tokenizer
+    assert processor.guide is not None
+    assert processor.tensor_adapter.library_name == "torch"
+
+
+def test_structured_init_cfg_logits_processor(tokenizer):
+    processor = CFGLogitsProcessor(
+        cfg_str=arithmetic_grammar,
+        tokenizer=tokenizer,
+        tensor_library_name="torch",
+    )
+    assert isinstance(processor, CFGLogitsProcessor)
+    assert processor.tokenizer is tokenizer
+    assert processor.guide is not None
+    assert processor.tensor_adapter.library_name == "torch"
+
+
+def test_structured_cfg_logits_processor_call(tokenizer):
+    processor = CFGLogitsProcessor(
+        cfg_str=arithmetic_grammar,
+        tokenizer=tokenizer,
+        tensor_library_name="torch",
+    )
+    vocab_token_ids = list(tokenizer.vocabulary.values())
+    logits = torch.randn(1, len(vocab_token_ids))
+    input_ids = torch.randint(0, len(vocab_token_ids), (1, 10))
+    output = processor(input_ids, logits)
+    assert output.shape == (1, len(vocab_token_ids))

--- a/tests/processors/test_tensor_adapters.py
+++ b/tests/processors/test_tensor_adapters.py
@@ -1,0 +1,276 @@
+import pytest
+from pytest import mark
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tensorflow as tf
+import torch
+
+from outlines.processors.tensor_adapters import (
+    NumpyTensorAdapter,
+    TorchTensorAdapter,
+    MLXTensorAdapter,
+    JAXTensorAdapter,
+    TensorFlowTensorAdapter,
+)
+
+try:
+    import mlx_lm
+    import mlx.core as mx
+
+    HAS_MLX = mx.metal.is_available()
+except ImportError:
+    HAS_MLX = False
+
+
+adapters = {
+    "jax": JAXTensorAdapter(),
+    "numpy": NumpyTensorAdapter(),
+    "tensorflow": TensorFlowTensorAdapter(),
+    "torch": TorchTensorAdapter(),
+}
+if HAS_MLX:
+    adapters["mlx"] = MLXTensorAdapter()
+
+frameworks = ["jax", "numpy", "tensorflow", "torch", "mlx"]
+
+def create_tensor(framework, shape, dtype=None):
+    if framework == "torch":
+        return torch.randn(*shape)
+    elif framework == "numpy":
+        return np.random.randn(*shape)
+    elif framework == "jax":
+        key = jax.random.PRNGKey(0)
+        return jax.random.normal(key, shape=shape)
+    elif framework == "tensorflow":
+        return tf.random.normal(shape)
+    elif framework == "mlx":
+        if not HAS_MLX:
+            pytest.skip("MLX not available")
+        return mx.random.normal(shape)
+
+def compare_tensors(framework, tensor1, tensor2):
+    if framework == "torch":
+        return torch.allclose(tensor1, tensor2)
+    elif framework == "numpy":
+        return np.array_equal(tensor1, tensor2)
+    elif framework == "jax":
+        return jax.numpy.array_equal(tensor1, tensor2)
+    elif framework == "tensorflow":
+        return tf.reduce_all(tf.equal(tensor1, tensor2))
+    elif framework == "mlx":
+        if not HAS_MLX:
+            pytest.skip("MLX not available")
+        return mx.array_equal(tensor1, tensor2)
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_shape(framework):
+    # 1d tensor
+    tensor_1d = create_tensor(framework, (2,))
+    result_1d = adapters[framework].shape(tensor_1d)
+    assert len(result_1d) == 1
+    assert result_1d[0] == 2
+
+    # 2d tensor
+    tensor_2d = create_tensor(framework, (2, 3))
+    result_2d = adapters[framework].shape(tensor_2d)
+    assert len(result_2d) == 2
+    assert result_2d[0] == 2
+    assert result_2d[1] == 3
+
+    # 3d tensor
+    tensor_3d = create_tensor(framework, (2, 2, 3))
+    result_3d = adapters[framework].shape(tensor_3d)
+    assert len(result_3d) == 3
+    assert result_3d[0] == 2
+    assert result_3d[1] == 2
+    assert result_3d[2] == 3
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_unsqueeze(framework):
+    # 1d tensor
+    tensor_1d = create_tensor(framework, (2,))
+    result_1d = adapters[framework].unsqueeze(tensor_1d)
+    assert result_1d.shape == (1, 2)
+
+    # 2d tensor
+    tensor_2d = create_tensor(framework, (2, 3))
+    result_2d = adapters[framework].unsqueeze(tensor_2d)
+    assert result_2d.shape == (1, 2, 3)
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_squeeze(framework):
+    # 1d tensor
+    tensor_1d = create_tensor(framework, (1,))
+    result_1d = adapters[framework].squeeze(tensor_1d)
+    with pytest.raises(TypeError):
+        len(result_1d)
+
+    # 2d tensor
+    tensor_2d = create_tensor(framework, (1, 2))
+    result_2d = adapters[framework].squeeze(tensor_2d)
+    assert result_2d.shape == (2,)
+
+    # 3d tensor
+    tensor_3d = create_tensor(framework, (1, 2, 3))
+    result_3d = adapters[framework].squeeze(tensor_3d)
+    assert result_3d.shape == (2, 3)
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_to_list(framework):
+    # 1d tensor
+    tensor_1d = create_tensor(framework, (2,))
+    result_1d = adapters[framework].to_list(tensor_1d)
+    assert isinstance(result_1d, list)
+    assert len(result_1d) == 2
+
+    # 2d tensor
+    tensor_2d = create_tensor(framework, (2, 3))
+    result_2d = adapters[framework].to_list(tensor_2d)
+    assert isinstance(result_2d, list)
+    assert len(result_2d) == 2
+    assert len(result_2d[0]) == 3
+    assert len(result_2d[1]) == 3
+
+    # 3d tensor
+    tensor_3d = create_tensor(framework, (2, 2, 3))
+    result_3d = adapters[framework].to_list(tensor_3d)
+    assert isinstance(result_3d, list)
+    assert len(result_3d) == 2
+    assert len(result_3d[0]) == 2
+    assert len(result_3d[1]) == 2
+    assert len(result_3d[0][0]) == 3
+    assert len(result_3d[0][1]) == 3
+    assert len(result_3d[1][0]) == 3
+    assert len(result_3d[1][1]) == 3
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_to_scalar(framework):
+    # multi-elements tensor, should raise an error
+    tensor_multi = create_tensor(framework, (2, 3))
+    if framework == "torch":
+        with pytest.raises(RuntimeError):
+            adapters[framework].to_scalar(tensor_multi)
+    else:
+        with pytest.raises(ValueError):
+            adapters[framework].to_scalar(tensor_multi)
+
+    # single-element tensor
+    tensor_single = create_tensor(framework, (1, 1))
+    scalar = adapters[framework].to_scalar(tensor_single)
+    assert isinstance(scalar, float)
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_full_like(framework):
+    tensor = create_tensor(framework, (2, 3))
+    result = adapters[framework].full_like(tensor, 0)
+    assert result.shape == (2, 3)
+    for i in range(2):
+        for j in range(3):
+            assert result[i, j] == 0
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_concatenate(framework):
+    # 1d tensors
+    tensor1 = create_tensor(framework, (2,))
+    tensor2 = create_tensor(framework, (2,))
+    result = adapters[framework].concatenate([tensor1, tensor2])
+    assert result.shape == (4,)
+    assert result[0] == tensor1[0]
+    assert result[1] == tensor1[1]
+    assert result[2] == tensor2[0]
+    assert result[3] == tensor2[1]
+
+    # 2d tensors
+    tensor1 = create_tensor(framework, (2, 3))
+    tensor2 = create_tensor(framework, (2, 3))
+    result = adapters[framework].concatenate([tensor1, tensor2])
+    assert result.shape == (4, 3)
+    for i in range(2):
+        for j in range(3):
+            assert result[i, j] == tensor1[i, j]
+            assert result[i + 2, j] == tensor2[i, j]
+
+    # 3d tensors
+    tensor1 = create_tensor(framework, (2, 2, 3))
+    tensor2 = create_tensor(framework, (2, 2, 3))
+    result = adapters[framework].concatenate([tensor1, tensor2])
+    assert result.shape == (4, 2, 3)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                assert result[i, j, k] == tensor1[i, j, k]
+                assert result[i + 2, j, k] == tensor2[i, j, k]
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_get_to_device(framework):
+    tensor = create_tensor(framework, (2, 3))
+    device = adapters[framework].get_device(tensor)
+    device_tensor = adapters[framework].to_device(tensor, device)
+
+    if framework == "torch":
+        assert isinstance(device_tensor.device.type, str)
+        assert compare_tensors(framework, device_tensor, tensor)
+    else:
+        assert compare_tensors(framework, device_tensor, tensor)
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_boolean_ones_like(framework):
+    tensor = create_tensor(framework, (2, 3))
+    ones = adapters[framework].boolean_ones_like(tensor)
+
+    assert ones.shape == (2, 3)
+    for i in range(2):
+        for j in range(3):
+            assert ones[i, j]
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_apply_mask(framework):
+    tensor = create_tensor(framework, (2, 3))
+
+    if framework == "torch":
+        mask = torch.randn(2, 3) > 0
+    elif framework == "numpy":
+        mask = np.random.randn(2, 3) > 0
+    elif framework == "jax":
+        key = jax.random.PRNGKey(0)
+        mask = jax.random.normal(key, shape=(2, 3)) > 0
+    elif framework == "tensorflow":
+        mask = tf.random.normal((2, 3)) > 0
+    elif framework == "mlx":
+        if not HAS_MLX:
+            pytest.skip("MLX not available")
+        mask = mx.random.normal((2, 3)) > 0
+
+    masked = adapters[framework].apply_mask(tensor, mask, float("-inf"))
+
+    assert masked.shape == (2, 3)
+    for i in range(2):
+        for j in range(3):
+            if mask[i, j]:
+                assert masked[i, j] == float("-inf")
+            else:
+                assert masked[i, j] == tensor[i, j]
+
+
+@pytest.mark.parametrize("framework", frameworks)
+def test_tensor_adapter_argsort_descending(framework):
+    tensor = create_tensor(framework, (2, 3))
+    indices = adapters[framework].argsort_descending(tensor)
+
+    assert indices.shape == (2, 3)
+    for i in range(2):
+        sorted_values = [tensor[i][idx] for idx in indices[i]]
+        for j in range(len(sorted_values) - 1):
+            assert sorted_values[j] >= sorted_values[j + 1]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -34,6 +34,7 @@ def sample_processor():
     processor = RegexLogitsProcessor(
         regex_string="[0-9]{3}",
         tokenizer=model.tokenizer,
+        tensor_library_name=model.tensor_library_name,
     )
     return processor
 
@@ -62,14 +63,29 @@ def test_steerable_generator_init_invalid_processor(steerable_model):
         SteerableGenerator.from_processor(steerable_model, Literal["foo", "bar"])
 
 
-def test_steerable_generator_init_valid_output_type(steerable_model):
+def test_steerable_generator_init_cfg_output_type(steerable_model):
+    generator = SteerableGenerator(steerable_model, CFG('start: "a"'))
+    assert generator.model == steerable_model
+    assert isinstance(generator.logits_processor, OutlinesLogitsProcessor)
+
+
+def test_steerable_generator_init_fsm_output_type(steerable_model):
+    generator = SteerableGenerator(
+        steerable_model,
+        FSM(interegular.parse_pattern(r"abc").to_fsm())
+    )
+    assert generator.model == steerable_model
+    assert isinstance(generator.logits_processor, OutlinesLogitsProcessor)
+
+
+def test_steerable_generator_init_other_output_type(steerable_model):
     generator = SteerableGenerator(steerable_model, Literal["foo", "bar"])
     assert generator.model == steerable_model
     assert isinstance(generator.logits_processor, OutlinesLogitsProcessor)
 
 
 def test_steerable_generator_init_invalid_output_type(steerable_model, sample_processor):
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         SteerableGenerator(steerable_model, sample_processor)
 
 


### PR DESCRIPTION
This PR addresses issue #1445 

The PR creates classes of type `TensorHandler` for various tensor libraries. Such classes are used by the logit processors to avoid having to manipulate the `input_its/logits` tensors itself. This solution allows us not to require the user to download all tensor libraries supported by outlines and to treat the tensor in their native type without having to turn them into torch tensors. We also modify the local models to possess an attribute `tensor_library_name` to indicate to the logits processor what `TensorHandler` implementation to use.

Thanks to those change, we remove the mandatory dependencies on torch and numpy.