### PR TITLE
Restore index caching

### DIFF
--- a/outlines/processors/guide.py
+++ b/outlines/processors/guide.py
@@ -15,6 +15,7 @@ from outlines_core.fsm.guide import (
 )
 
 from outlines import grammars
+from outlines.caching import cache
 from outlines.fsm.parsing import PartialLark, PartialParserState
 
 if TYPE_CHECKING:
@@ -72,6 +73,7 @@ class StopAtEOSGuide(Guide):
         return self
 
 
+@cache()
 def cached_create_states_mapping(regex_string, tokenizer, *args, **kwargs):
     return uncached_create_states_mapping(regex_string, tokenizer, *args, **kwargs)
 


### PR DESCRIPTION
Addresses issue #1466 

Caching for the creation of the states mapping in the `RegexGuide` was removed in PR #1278 to address issue #1274 highlighting that the cache is causing an error.

As I cannot reproduce the error with the v1.0 branch of Outlines using `outlines_core==0.1.26`, I propose we simply restore the cache on the function `cached_create_states_mapping` (and add tests for it).

