### PR TITLE
Allow the OpenAI model to return multiple completions

### DIFF
--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -197,13 +197,17 @@ class OpenAI(Model):
             else:
                 raise e
 
-        message = result.choices[0].message
-        if message.refusal is not None:
-            raise ValueError(
-                f"OpenAI refused to answer the request: {result.choices[0].refusal}"
-            )
+        messages = [choice.message for choice in result.choices]
+        for message in messages:
+            if message.refusal is not None:
+                raise ValueError(
+                    f"OpenAI refused to answer the request: {message.refusal}"
+                )
 
-        return message.content
+        if len(messages) == 1:
+            return messages[0].content
+        else:
+            return [message.content for message in messages]
 
     def generate_stream(
         self,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -87,6 +87,16 @@ def test_openai_simple_call():
 
 
 @pytest.mark.api_call
+def test_openai_simple_call_multiple_samples():
+    model = OpenAI(OpenAIClient(), MODEL_NAME)
+    result = model.generate("Respond with one word. Not more.", n=2)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], str)
+
+
+@pytest.mark.api_call
 def test_openai_direct_call():
     model = OpenAI(OpenAIClient(), MODEL_NAME)
     result = model("Respond with one word. Not more.")


### PR DESCRIPTION
Addresses issue #1511 

There was an issue with the OpenAI model: it was returning one completion regardless of what was received from the client. This PR changes it such that the model returns as many completions as it gets.