### PR TITLE
Update Model JSON Validation to Pydantic V2 Style

### DIFF
--- a/outlines/generate/json.py
+++ b/outlines/generate/json.py
@@ -50,7 +50,7 @@ def json(
         schema = pyjson.dumps(schema_object.model_json_schema())
         regex_str = build_regex_from_schema(schema, whitespace_pattern)
         generator = regex(model, regex_str, sampler)
-        generator.format_sequence = lambda x: schema_object.parse_raw(x)
+        generator.format_sequence = lambda x: schema_object.model_validate_json(x)
     elif isinstance(schema_object, type(Enum)):
         schema = pyjson.dumps(get_schema_from_enum(schema_object))
         regex_str = build_regex_from_schema(schema, whitespace_pattern)
@@ -95,7 +95,7 @@ def json_openai(
         schema = schema_object.model_json_schema()
         schema["additionalProperties"] = False
         schema = pyjson.dumps(schema)
-        format_sequence = lambda x: schema_object.parse_raw(x)
+        format_sequence = lambda x: schema_object.model_validate_json(x)
     elif isinstance(schema_object, str):
         schema = schema_object
         format_sequence = lambda x: pyjson.loads(x)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -99,7 +99,7 @@ def test_openai_json_call_pydantic():
     # assert success for valid response
     with patched_openai(completion=completion) as model:
         generator = generate.json(model, Person)
-        assert generator("fastest person") == Person.parse_raw(completion)
+        assert generator("fastest person") == Person.model_validate_json(completion)
 
     # assert fail for non-json response
     with patched_openai(completion="usain bolt") as model:


### PR DESCRIPTION
Currently when parsing JSON responses from LLMs into the Pydantic BaseModel, `parse_raw` is being used. This is [deprecated behavior as of Pydantic v2](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel) and is slated to be removed in the future. The new behavior is to use `model_validate_json` which behaves the same way.

No warnings are observed as all migration warnings are [suppressed](https://github.com/dottxt-ai/outlines/blob/main/pyproject.toml#L106).

It is best to migrate now before this causes issues. Outlines already [depends on Pydantic v2](https://github.com/dottxt-ai/outlines/blob/main/pyproject.toml#L34) so there is no need to support any behavior from Pydantic v1.