### PR TITLE
Add optional tokenizer paramers to generation

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -224,6 +224,8 @@ class Transformers:
         The generated text
         """
         prompts = prompts if isinstance(prompts, list) else [prompts]
+        tokenizer_parameters = tokenizer_parameters or {}
+
         input_ids, attention_mask = self.tokenizer.encode(prompts, **tokenizer_parameters)
 
         inputs = {

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -200,6 +200,7 @@ class Transformers:
         generation_parameters: GenerationParameters,
         logits_processor: Optional["OutlinesLogitsProcessor"],
         sampling_parameters: SamplingParameters,
+        tokenizer_parameters: Optional[dict] = None,
     ) -> Union[str, List[str], List[List[str]]]:
         """Generate text using `transformers`.
 
@@ -222,11 +223,8 @@ class Transformers:
         -------
         The generated text
         """
-        if isinstance(prompts, str):
-            # convert to 2d
-            input_ids, attention_mask = self.tokenizer.encode([prompts])
-        else:
-            input_ids, attention_mask = self.tokenizer.encode(prompts)
+        prompts = prompts if isinstance(prompts, list) else [prompts]
+        input_ids, attention_mask = self.tokenizer.encode(prompts, **tokenizer_parameters)
 
         inputs = {
             "input_ids": input_ids.to(self.model.device),


### PR DESCRIPTION
The title and the changes speak for themselves, I hope. In my case, this change was necessary to [handle a bug with the Gemma 3 models](https://github.com/google-deepmind/gemma/issues/169) whose fix involves passing additional parameters to the tokenizer when encoding the prompt. However, I think my changes allow for overall greater flexibility.

I didn't run the tests locally because it's a minimal change and I couldn't be bothered to install all of the additional libraries. I did run the pre-commit though and got no errors.