### PR TITLE
Fix errors in the mlx tensor adapter

### DIFF
--- a/outlines/processors/tensor_adapters/base.py
+++ b/outlines/processors/tensor_adapters/base.py
@@ -1,4 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import Any, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
 
 
 class TensorAdapter(ABC):
@@ -8,6 +12,11 @@ class TensorAdapter(ABC):
     manipulate tensors in different libraries. Concrete implementations of
     this class should provide specific implementations for each method as
     well as providing a library_name attribute.
+
+    TODO: Update the version of outlines-core used to receive plain arrays
+    instead of torch tensors. In the meantime, implementations of this class
+    must make sure that their `full_like` and `concatenate` methods can
+    handle torch tensors.
     """
     library_name: str
 
@@ -37,13 +46,20 @@ class TensorAdapter(ABC):
         ...
 
     @abstractmethod
-    def full_like(self, tensor, fill_value):
-        """Create a tensor with the same shape as the input tensor filled with a scalar value"""
+    def full_like(self, tensor: "torch.Tensor", fill_value):
+        """Create a tensor with the same shape as the input tensor filled
+        with a scalar value.
+        ATTENTION: This method receives a torch tensor regardless of the
+        library used.
+        """
         ...
 
     @abstractmethod
-    def concatenate(self, tensors):
-        """Concatenate a list of tensors along a specified dimension"""
+    def concatenate(self, tensors: list[Union["torch.Tensor", Any]]):
+        """Concatenate a list of tensors along a specified dimension.
+        ATTENTION: This method can either receive a list of torch tensors or
+        a list of tensors from the library used.
+        """
         ...
 
     @abstractmethod

--- a/outlines/processors/tensor_adapters/mlx.py
+++ b/outlines/processors/tensor_adapters/mlx.py
@@ -27,10 +27,18 @@ class MLXTensorAdapter(TensorAdapter):
         return tensor.item()
 
     def full_like(self, tensor, fill_value):
-        return self.mlx.full(tensor.shape, fill_value, dtype=tensor.dtype)
+        # Compatible with receiving a torch tensor
+        return self.mlx.full(tensor.shape, fill_value)
 
     def concatenate(self, tensors):
-        return self.mlx.concat(tensors, axis=0)
+        # Can handle both torch and mlx tensors
+        return self.mlx.concatenate(
+            [
+                self.mlx.array(t) if not isinstance(t, self.mlx.array) else t
+                for t in tensors
+            ],
+            axis=0
+        )
 
     def get_device(self, tensor):
         return None


### PR DESCRIPTION
As the `allowed_tokens` returned by the `guide` object coming from outlines-core, we need to ensure the `full_like` and the `concatenate` methods of tensor handlers can handle torch tensors as those `allowed_tokens` are passed as arguments to them. This was already the case for all tensor adapters except `mlx`.

In the future, we need to look at upgrading `outlines-core` to be able to fully remove the dependency on `torch`