### PR TITLE
Make docs "blog" link to blog.dottxt.co

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,4 +180,4 @@ nav:
       - How to contribute 🏗️: community/contribute.md
       - Your projects 👏: community/examples.md
       - Versioning Guide 📌: community/versioning.md
-  - Blog: blog/index.md
+  - Blog: https://blog.dottxt.co


### PR DESCRIPTION
Redirects the blog to blog.dottxt.co, rather than use the one in our docs. This is also addressed for the v1 docs in #1529.