### PR TITLE
Change the deprecation warning of v0 from v1.5.0 to v.1.1.0

### DIFF
--- a/outlines/models/llamacpp.py
+++ b/outlines/models/llamacpp.py
@@ -233,7 +233,7 @@ class LlamaCpp(Model):
     def load_lora(self, adapter_path: str):  # pragma: no cover
         warnings.warn("""
             The `load_lora` method is deprecated starting from v1.0.0.
-            Support for it will be removed in v1.5.0.
+            Support for it will be removed in v1.1.0.
             """,
             DeprecationWarning,
             stacklevel=2,

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -181,7 +181,7 @@ class OpenAI(Model):
         if isinstance(model_name, OpenAIConfig) or kwargs.get("config"):
             warnings.warn("""
                 The `openai` function is deprecated starting from v1.0.0.
-                Do not use it. Support for it will be removed in v1.5.0.
+                Do not use it. Support for it will be removed in v1.1.0.
                 Instead, you should instantiate a `OpenAI` model with the
                 `outlines.from_openai` function that takes an openai library
                 client and a model name as arguments. Similarly, you cannot

--- a/outlines/models/vllm_offline.py
+++ b/outlines/models/vllm_offline.py
@@ -143,7 +143,7 @@ class VLLMOffline(Model):
     def load_lora(self, adapter_path: Optional[str]):
         warnings.warn("""
             The `load_lora` method is deprecated starting from v1.0.0.
-            Support for it will be removed in v1.5.0.
+            Support for it will be removed in v1.1.0.
             Please use the v1 of the `outlines` library by using the
             `outlines.from_vllm` function to create a `VLLM` model
             instance.

--- a/outlines/v0_legacy/function.py
+++ b/outlines/v0_legacy/function.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING: # pragma: no cover
 def function_warning():
     warnings.warn("""
         The `Function` class is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should use the `outlines.Application` class that
         implements a similar functionality.
         An `Application` is initialized with a prompt template and an

--- a/outlines/v0_legacy/generate/cfg.py
+++ b/outlines/v0_legacy/generate/cfg.py
@@ -20,7 +20,7 @@ def cfg(
     """Generate text in the language of a Context-Free Grammar
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -51,7 +51,7 @@ def cfg(
 
     warnings.warn("""
         The `cfg` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/choice.py
+++ b/outlines/v0_legacy/generate/choice.py
@@ -24,7 +24,7 @@ def choice(
     """Generate a choice from a list of options.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -53,7 +53,7 @@ def choice(
     """
     warnings.warn("""
         The `choice` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/format.py
+++ b/outlines/v0_legacy/generate/format.py
@@ -18,7 +18,7 @@ def format(
     """Generate structured data that can be parsed as a Python type.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead::
 
     ```python
@@ -47,7 +47,7 @@ def format(
     """
     warnings.warn("""
         The `format` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/fsm.py
+++ b/outlines/v0_legacy/generate/fsm.py
@@ -21,7 +21,7 @@ def fsm(
     """Generate text that follows a Finite State Machine.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -52,7 +52,7 @@ def fsm(
     """
     warnings.warn("""
         The `fsm` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/json.py
+++ b/outlines/v0_legacy/generate/json.py
@@ -27,7 +27,7 @@ def json(
     """Generate structured text that follows a JSON Schema.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -62,7 +62,7 @@ def json(
     """
     warnings.warn("""
         The `json` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/regex.py
+++ b/outlines/v0_legacy/generate/regex.py
@@ -14,7 +14,7 @@ def regex(model, regex_str: str | Regex, sampler: Sampler = multinomial()):
     """Generate structured text in the language of a regular expression.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -43,7 +43,7 @@ def regex(model, regex_str: str | Regex, sampler: Sampler = multinomial()):
     """
     warnings.warn("""
         The `regex` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/generate/text.py
+++ b/outlines/v0_legacy/generate/text.py
@@ -19,7 +19,7 @@ def text(model, sampler: Sampler = multinomial()) -> Union[
     """Generate unconstrained text.
 
     This function is deprecated starting from v1.0.0. Do not use it.
-    Support for it will be removed in v1.5.0.
+    Support for it will be removed in v1.1.0.
     Use the `Generator` object instead:
 
     ```python
@@ -44,7 +44,7 @@ def text(model, sampler: Sampler = multinomial()) -> Union[
     """
     warnings.warn("""
         The `text` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Use the `Generator` object instead:
         ```python
         from outlines import Generator

--- a/outlines/v0_legacy/models/exllamav2.py
+++ b/outlines/v0_legacy/models/exllamav2.py
@@ -64,7 +64,7 @@ class ExLlamaV2Model():
     ):
         warnings.warn("""
             The `ExLlamaV2Model` model is deprecated starting from v1.0.0.
-            Support for it will be removed in v1.5.0.
+            Support for it will be removed in v1.1.0.
             As the `exllamav2` library is not compatible with some key features
             of `outlines`, we decided to remove support for it.
             """,

--- a/outlines/v0_legacy/models/llamacpp.py
+++ b/outlines/v0_legacy/models/llamacpp.py
@@ -108,7 +108,7 @@ def llamacpp(
 
     warnings.warn("""
         The `llamacpp` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `LlamaCpp` model with the
         `outlines.from_llamacpp` function that takes a `llama_cpp.Llama`
         instance as argument. For example:

--- a/outlines/v0_legacy/models/mlxlm.py
+++ b/outlines/v0_legacy/models/mlxlm.py
@@ -117,7 +117,7 @@ def mlxlm(
     """
     warnings.warn("""
         The `mlxlm` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `MLXLM` model with the
         `outlines.from_mlxlm` function that takes a mlxlm model
         and a tokenizer as arguments. For example:

--- a/outlines/v0_legacy/models/transformers.py
+++ b/outlines/v0_legacy/models/transformers.py
@@ -107,7 +107,7 @@ def transformers(
     """
     warnings.warn("""
         The `transformers` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `Transformers` model with the
         `outlines.from_transformers` function that takes a transformers model
         and a tokenizer as arguments. For example:
@@ -155,7 +155,7 @@ def mamba(
 ):
     warnings.warn("""
         The `mamba` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `Transformers` model with the
         `outlines.from_transformers` function that takes a transformers model
         and a tokenizer as arguments. For Mamba, you would use a mamba model

--- a/outlines/v0_legacy/models/transformers_vision.py
+++ b/outlines/v0_legacy/models/transformers_vision.py
@@ -68,7 +68,7 @@ def transformers_vision(
     """
     warnings.warn("""
         The `transformers_vision` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `TransformersMultiModal` model with
         the `outlines.from_transformers` function that takes a transformers
         model and a processor as arguments. For example:

--- a/outlines/v0_legacy/models/vllm_offline.py
+++ b/outlines/v0_legacy/models/vllm_offline.py
@@ -80,7 +80,7 @@ def vllm(model_name: str, **vllm_model_params):
     """
     warnings.warn("""
         The `vllm` function is deprecated starting from v1.0.0.
-        Do not use it. Support for it will be removed in v1.5.0.
+        Do not use it. Support for it will be removed in v1.1.0.
         Instead, you should instantiate a `VLLMOffline` model with the
         `outlines.from_vllm_offline` function that takes a vLLM model name as
         argument.


### PR DESCRIPTION
After talking about it, we decided we should remove those deprecated features sooner so we don't have to deal with them for so long.