### PR TITLE
Modify Application's call method to include inference kwargs

### DIFF
--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -53,14 +53,14 @@ def test_application_generator_no_model():
     application = Application(template, output_type)
 
     with pytest.raises(ValueError):
-        application(None)
+        application(None, {"value": "example"})
 
 
 def test_application_template_call(model):
     template = Template.from_string("Test {{ value }}")
     output_type = None
     application = Application(template, output_type)
-    result = application(model, value="example")
+    result = application(model, {"value": "example"}, foo="bar")
 
     assert result == "Test example"
 
@@ -71,7 +71,7 @@ def test_application_callable_call(model):
 
     output_type = None
     application = Application(template, output_type)
-    result = application(model, value="example")
+    result = application(model, {"value": "example"}, foo="bar")
 
     assert result == "Test example"
 
@@ -82,7 +82,7 @@ def test_application_template_error(model):
     application = Application(template, output_type)
 
     with pytest.raises(jinja2.exceptions.UndefinedError):
-        application(model, foo="bar")
+        application(model, {"foo": "bar"})
 
 
 def test_application_generator_reuse(model, another_model):
@@ -90,15 +90,15 @@ def test_application_generator_reuse(model, another_model):
     output_type = None
     application = Application(template, output_type)
 
-    application(model, value="example")
+    application(model, {"value": "example"})
     first_generator = application.generator
     first_model = application.model
 
-    application(model, value="example")
+    application(model, {"value": "example"})
     assert application.model == first_model
     assert application.generator == first_generator
 
-    application(another_model, value="example")
+    application(another_model, {"value": "example"})
     assert application.model == another_model
     assert application.model != first_model
     assert application.generator != first_generator


### PR DESCRIPTION
Addresses #1576 

I propose to have users put their template args in a dict instead of their inference kwargs because the list of the template variables is fixed while they may want to add/remove optional inference parameters.

A consequence of this change is that users cannot provide template variables as positional arguments as they used to be able to if the template was a callable, but I think it's for the best.