### PR TITLE
Update the Gemini model to use their new sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
     "openai>=1.0.0",
     "datasets",
     "anthropic",
-    "google-generativeai",
+    "google-genai",
     "transformers",
     "pillow",
     "jax",

--- a/tests/models/test_gemini_type_adapter.py
+++ b/tests/models/test_gemini_type_adapter.py
@@ -1,13 +1,13 @@
 import io
-import json
 import pytest
 import sys
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Literal, get_args
+from typing import Literal
 
 from PIL import Image
 from genson import SchemaBuilder
+from google.genai import types
 from pydantic import BaseModel
 
 from outlines import cfg, json_schema, regex
@@ -62,7 +62,11 @@ def test_gemini_type_adapter_input_text(adapter):
 def test_gemini_type_adapter_input_vision(adapter, image):
     input_message = Vision("hello", image)
     result = adapter.format_input(input_message)
-    assert result == {"contents": [input_message.prompt, input_message.image]}
+    image_part = types.Part.from_bytes(
+        data=input_message.image_str,
+        mime_type=input_message.image_format
+    ),
+    assert result == {"contents": [input_message.prompt, image_part]}
 
 
 def test_dottxt_type_adapter_input_invalid(adapter):


### PR DESCRIPTION
Addresses #1581 

This PR modifies the `Gemini` model to take a `google.genai.Client` instance as an argument instead of a `google.generativeai.GenerativeModel` instance. It modifies the methods of the model to adapt to the interface of the new client and updates the tests acordingly. A notable change is that the model and its loader function now have an optional `model_name` parameter.

I have not updated the documentation as it's handled by this ongoing PR #1577 