### PR TITLE
Rename SgLang into SGLang

### DIFF
--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -16,7 +16,7 @@ from .llamacpp import LlamaCpp, from_llamacpp
 from .mlxlm import MLXLM, from_mlxlm
 from .ollama import Ollama, from_ollama
 from .openai import from_openai, OpenAI
-from .sglang import from_sglang, SGLang, AsyncSgLang
+from .sglang import from_sglang, SGLang, AsyncSGLang
 from .tgi import from_tgi, TGI, AsyncTGI
 from .transformers import (
     Transformers,
@@ -35,7 +35,7 @@ SteerableModel = Union[LlamaCpp, MLXLM, Transformers, VLLMOffline]
 BlackBoxModel = Union[
     Anthropic,
     AsyncTGI,
-    AsyncSgLang,
+    AsyncSGLang,
     AsyncVLLM,
     Dottxt,
     Gemini,

--- a/outlines/models/sglang.py
+++ b/outlines/models/sglang.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from openai import AsyncOpenAI, OpenAI
 
 
-class SgLangTypeAdapter(ModelTypeAdapter):
+class SGLangTypeAdapter(ModelTypeAdapter):
 
     def format_input(self, model_input):
         """Generate the prompt argument to pass to the client.
@@ -71,7 +71,7 @@ class SGLang(Model):
         """
         self.client = client
         self.model_name = model_name
-        self.type_adapter = SgLangTypeAdapter()
+        self.type_adapter = SGLangTypeAdapter()
 
     def generate(self, model_input, output_type, **inference_kwargs):
         """Generate text using the client.
@@ -156,11 +156,11 @@ class SGLang(Model):
         return client_args
 
 
-class AsyncSgLang(AsyncModel):
+class AsyncSGLang(AsyncModel):
     """Represents an async client to a `sglang` server."""
 
     def __init__(self, client, model_name: Optional[str] = None):
-        """Create an `AsyncSgLang` model instance.
+        """Create an `AsyncSGLang` model instance.
 
         Parameters
         ----------
@@ -170,7 +170,7 @@ class AsyncSgLang(AsyncModel):
         """
         self.client = client
         self.model_name = model_name
-        self.type_adapter = SgLangTypeAdapter()
+        self.type_adapter = SGLangTypeAdapter()
 
     async def generate(self, model_input, output_type, **inference_kwargs):
         """Generate text using `sglang`.
@@ -259,13 +259,13 @@ class AsyncSgLang(AsyncModel):
 def from_sglang(
     client: Union["OpenAI", "AsyncOpenAI"],
     model_name: Optional[str] = None,
-) -> Union[SGLang, AsyncSgLang]:
+) -> Union[SGLang, AsyncSGLang]:
     from openai import AsyncOpenAI, OpenAI
 
     if isinstance(client, OpenAI):
         return SGLang(client, model_name)
     elif isinstance(client, AsyncOpenAI):
-        return AsyncSgLang(client, model_name)
+        return AsyncSGLang(client, model_name)
     else:
         raise ValueError(
             f"Unsupported client type: {type(client)}.\n"

--- a/tests/models/test_sglang.py
+++ b/tests/models/test_sglang.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator, Generator
 import pytest
 from openai import AsyncOpenAI, OpenAI
 
-from outlines.models.sglang import SGLang, AsyncSgLang, from_sglang
+from outlines.models.sglang import SGLang, AsyncSGLang, from_sglang
 from outlines.types.dsl import CFG, Regex, JsonSchema
 from tests.test_utils.mock_openai_client import MockOpenAIClient, MockAsyncOpenAIClient
 
@@ -130,12 +130,12 @@ def sync_model_no_model_name():
 
 @pytest.fixture
 def async_model():
-    return AsyncSgLang(async_openai_client, model_name=sglang_model_name)
+    return AsyncSGLang(async_openai_client, model_name=sglang_model_name)
 
 
 @pytest.fixture
 def async_model_no_model_name():
-    return AsyncSgLang(async_openai_client)
+    return AsyncSGLang(async_openai_client)
 
 
 def test_sglang_init():
@@ -158,13 +158,13 @@ def test_sglang_init():
 
     # Async with model name
     model = from_sglang(async_openai_client, sglang_model_name)
-    assert isinstance(model, AsyncSgLang)
+    assert isinstance(model, AsyncSGLang)
     assert model.client == async_openai_client
     assert model.model_name == sglang_model_name
 
     # Async without model name
     model = from_sglang(async_openai_client)
-    assert isinstance(model, AsyncSgLang)
+    assert isinstance(model, AsyncSGLang)
     assert model.client == async_openai_client
     assert model.model_name is None
 

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -4,7 +4,7 @@ import pytest
 from dataclasses import dataclass
 
 from PIL import Image
-from outlines.models.sglang import SgLangTypeAdapter
+from outlines.models.sglang import SGLangTypeAdapter
 from outlines.types import CFG, JsonSchema
 
 from outlines import Vision
@@ -27,7 +27,7 @@ JSON_SCHEMA_STRING = """
 
 @pytest.fixture
 def type_adapter():
-    return SgLangTypeAdapter()
+    return SGLangTypeAdapter()
 
 @pytest.fixture
 def cfg_instance():


### PR DESCRIPTION
I realized that the g is capitalized in the name of this library, so we should rename our model to follow their spelling.