### PR TITLE
Restore deprecated regex DSL functions with a warning

### DIFF
--- a/outlines/types/__init__.py
+++ b/outlines/types/__init__.py
@@ -27,6 +27,9 @@ from outlines.types.dsl import (
     between,
     zero_or_more,
     one_or_more,
+    # deprecated
+    repeat,
+    times,
 )
 
 

--- a/outlines/types/dsl.py
+++ b/outlines/types/dsl.py
@@ -15,6 +15,7 @@ output types for structured generation:
 import json
 import re
 import sys
+import warnings
 from dataclasses import dataclass
 from enum import EnumMeta
 from types import FunctionType
@@ -199,6 +200,16 @@ class Term:
 
     def zero_or_more(self) -> "KleeneStar":
         return zero_or_more(self)
+
+    # deprecated
+    def times(self, count: int) -> "QuantifyExact":
+        return times(self, count)
+
+    # deprecated
+    def repeat(self, min_count: int, max_count: int) -> Union[
+        "QuantifyMinimum", "QuantifyMaximum", "QuantifyBetween"
+    ]:
+        return repeat(self, min_count, max_count)
 
 
 @dataclass
@@ -783,6 +794,99 @@ def _handle_dict(args: tuple, recursion_depth: int) -> Sequence:
             String("}"),
         ]
     )
+
+
+# deprecated
+def repeat(term: Term, min_count: int, max_count: int) -> Union[
+    QuantifyMinimum, QuantifyMaximum, QuantifyBetween
+]:
+    if min_count is None and max_count is None:
+        warnings.warn("""
+            The `repeat` function/method is deprecated starting from v0.2.2.
+            Do not use it. Support for it will be removed in v1.5.0.
+            Use `between`, `at_least` or `at_most` instead.
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise ValueError(
+            "You must provide a value for at least `min_count` or `max_count`"
+        )
+    if max_count is None:
+        warnings.warn("""
+            The `repeat` function/method is deprecated starting from v0.2.2.
+            Do not use it. Support for it will be removed in v1.5.0.
+            Use `at_least` instead.
+            For instance:
+            ```python
+            from outlines.types import Regex, at_least
+            digit = Regex(r'[0-9]')
+            # 2 ways of doing the same thing
+            at_least_5_digits = digit.at_least(5)
+            at_least_5_digits = at_least(digit, 5)
+            ```
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return at_least(min_count, term)
+    if min_count is None:
+        warnings.warn("""
+            The `repeat` function/method is deprecated starting from v0.2.2.
+            Do not use it. Support for it will be removed in v1.5.0.
+            Use `at_most` instead.
+            For instance:
+            ```python
+            from outlines.types import Regex, at_most
+            digit = Regex(r'[0-9]')
+            # 2 ways of doing the same thing
+            at_most_5_digits = digit.at_most(5)
+            at_most_5_digits = at_most(digit, 5)
+            ```
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return at_most(max_count, term)
+    else:
+        warnings.warn("""
+            The `repeat` function/method is deprecated starting from v0.2.2.
+            Do not use it. Support for it will be removed in v1.5.0.
+            Use `between` instead.
+            For instance:
+            ```python
+            from outlines.types import Regex, between
+            digit = Regex(r'[0-9]')
+            # 2 ways of doing the same thing
+            five_to_eight_digits = digit.between(5, 8)
+            five_to_eight_digits = between(digit, 5, 8)
+            ```
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return between(min_count, max_count, term)
+
+
+# deprecated
+def times(term: Term, count: int) -> QuantifyExact:
+    warnings.warn("""
+        The `times` function/method is deprecated starting from v0.2.2.
+        Do not use it. Support for it will be removed in v1.5.0.
+        Use `exactly` instead.
+        For instance:
+        ```python
+        from outlines.types import Regex, exactly
+        digit = Regex(r'[0-9]')
+        # 2 ways of doing the same thing
+        five_digits = digit.exactly(5)
+        five_digits = exactly(digit, 5)
+        ```
+        """,
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return exactly(count, term)
 
 
 def to_regex(term: Term) -> str:

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -52,6 +52,9 @@ from outlines.types.dsl import (
     exactly,
     regex,
     python_types_to_terms,
+    # deprecated
+    repeat,
+    times,
 )
 
 if sys.version_info >= (3, 12):
@@ -332,6 +335,49 @@ def test_dsl_aliases():
 
     test = json_schema('{"type": "string"}')
     assert isinstance(test, JsonSchema)
+
+
+def test_dsl_repeat():
+    with pytest.warns(
+        DeprecationWarning,
+        match="The `repeat` function/method is deprecated",
+    ):
+        a = String("a")
+
+        # error missing min_count or max_count
+        with pytest.raises(
+            ValueError,
+            match="You must provide a value for at least `min_count` or "
+            "`max_count`",
+        ):
+            repeat(a, None, None)
+
+        # at_least
+        assert repeat(a, 2, None) == at_least(2, a)
+        assert repeat("a", 2, None) == at_least(2, "a")
+        assert a.repeat(2, None) == a.at_least(2)
+
+        # at_most
+        assert repeat(a, None, 2) == at_most(2, a)
+        assert repeat("a", None, 2) == at_most(2, "a")
+        assert a.repeat(None, 2) == a.at_most(2)
+
+        # between
+        assert repeat(a, 1, 2) == between(1, 2, a)
+        assert repeat("a", 1, 2) == between(1, 2, "a")
+        assert a.repeat(1, 2) == a.between(1, 2)
+
+
+def test_dsl_times():
+    with pytest.warns(
+        DeprecationWarning,
+        match="The `times` function/method is deprecated",
+    ):
+        a = String("a")
+
+        assert times(a, 2) == exactly(2, a)
+        assert times("a", 2) == exactly(2, "a")
+        assert a.times(2) == a.exactly(2)
 
 
 def test_dsl_term_pydantic_simple():


### PR DESCRIPTION
This is the equivalent of #1532, but merging into v1 instead of main as the latter's tests are currently broken.