### PR TITLE
Fix typos in getting started guide

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -205,7 +205,7 @@ Supported output types can be organized in 5 categories:
 - [Multiple Choices](../../features/core/output_types#multiple-choices): using `Literal` or `Enum`
 - [JSON Schemas](../../features/core/output_types#json-schemas): using a wide range of possible objects including Pydantic models and dataclasses
 - [Regex](../../features/core/output_types#regex-patterns): through the Outlines's `Regex` object
-- [Context-free Grammarq](../../features/core/output_types#context-free-grammars): through the Outlines's `CFG` object
+- [Context-free Grammars](../../features/core/output_types#context-free-grammars): through the Outlines's `CFG` object
 
 Consult the section on [Output Types](../../features/core/output_types.md) in the features documentation for more detailed information on all supported types for each output type category.
 
@@ -228,8 +228,8 @@ In the meantime, you can find below examples of using each of the five output ty
 
     # Define our multiple choice output type
     class PizzaOrBurger(Enum):
-        pizza = "pizza
-        burger = "burger
+        pizza = "pizza"
+        burger = "burger"
 
     model = <your_model_as_defined_above>
 


### PR DESCRIPTION
## Description
This PR fixes minor typos found in the getting started documentation to improve readability and code examples.

## Changes Made
- **Line 74**: Fixed "Context-free Grammarq" to "Context-free Grammars" in the output types section
- **Multiple Choice example**: Fixed missing closing quote in enum definition: `pizza = "pizza"`, `burger = "burger"`

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified spelling corrections are accurate
- [x] Confirmed code examples are syntactically correct
- [x] Ran pre-commit hooks successfully

## Additional Context
These are minor documentation improvements that fix typos and ensure code examples are properly formatted. The changes maintain the original meaning while correcting syntax errors.
This is my first contribution to this project, but I wanted to make a small contribution by fixing this typo to help improve the project. 😊