### PR TITLE
Add support for the chat interface

### DIFF
--- a/example_chat.py
+++ b/example_chat.py
@@ -1,0 +1,51 @@
+# user provides Chat object
+import io
+import requests
+import PIL
+import openai
+import outlines
+
+from outlines.inputs import Chat, Vision
+
+model = outlines.from_openai(
+    openai.OpenAI(),
+    "gpt-4o"
+)
+
+def get_image(url):
+    r = requests.get(url)
+    return PIL.Image.open(io.BytesIO(r.content))
+
+# user provides Chat object
+prompt = Chat([
+    ("system", "You are a helpful assistant. Answer in French."),
+    ("user", "Just a random message, ignore it."),
+    ("user", Vision(get_image("https://picsum.photos/id/237/400/300"), "Describe this image"))
+])
+print(model(prompt, max_tokens=20))
+
+# user provides a string with chat tags/messages
+prompt = """
+{%system%} You are a helpful assistant. Answer in French.{%endsystem%} 
+{%user%} Just a random message, ignore it.{%enduser%} 
+{%user%} How are you doing?{%enduser%}
+"""
+print(model(prompt, max_tokens=20))
+
+# direct use of Vision (no chat)
+print(model(Vision(get_image("https://picsum.photos/id/237/400/300"), "Describe this image"), max_tokens=20))
+
+# example of how it would work with tools (not implemented yet)
+def get_weather(city):
+    return {"temperature": 25, "condition": "sunny"}
+
+def get_news(topic):
+    return {"news": "The weather in Paris is sunny and 25 degrees Celsius."}
+
+prompt = Chat([
+    ("system", "You are a helpful assistant. Answer in French. Use the tools provided to answer the user's question."),
+    ("user", "Tell me about the weather in Paris."),
+    ("assistant", "{'tool': 'get_weather', 'args': {'city': 'Paris'}}"),
+    ("function", "{'temperature': 25, 'condition': 'sunny'}")
+])
+print(model(prompt, max_tokens=20, tools=[get_weather, get_news]))

--- a/example_chat.py
+++ b/example_chat.py
@@ -5,7 +5,7 @@ import PIL
 import openai
 import outlines
 
-from outlines.inputs import Chat, Vision
+from outlines.inputs import Chat, Image
 
 model = outlines.from_openai(
     openai.OpenAI(),
@@ -18,34 +18,35 @@ def get_image(url):
 
 # user provides Chat object
 prompt = Chat([
-    ("system", "You are a helpful assistant. Answer in French."),
-    ("user", "Just a random message, ignore it."),
-    ("user", Vision(get_image("https://picsum.photos/id/237/400/300"), "Describe this image"))
+    ({"role": "system", "content": "You are a helpful assistant. Answer in French."}),
+    ({"role": "user", "content": "Just a random message, ignore it."}),
+    ({"role": "user", "content": "Describe this image", "items": [Image(get_image("https://picsum.photos/id/237/400/300"))]})
 ])
 print(model(prompt, max_tokens=20))
 
 # user provides a string with chat tags/messages
-prompt = """
+template_string = """
 {%system%} You are a helpful assistant. Answer in French.{%endsystem%} 
 {%user%} Just a random message, ignore it.{%enduser%} 
-{%user%} How are you doing?{%enduser%}
+{%user%} {{prompt}} {%enduser%}
 """
-print(model(prompt, max_tokens=20))
+template = outlines.templates.Template.from_string(template_string)
+print(model(template(prompt="How are you?"), max_tokens=20))
 
 # direct use of Vision (no chat)
-print(model(Vision(get_image("https://picsum.photos/id/237/400/300"), "Describe this image"), max_tokens=20))
+print(model("Describe this image", items=[Image(get_image("https://picsum.photos/id/237/400/300"))], max_tokens=20))
 
 # example of how it would work with tools (not implemented yet)
-def get_weather(city):
-    return {"temperature": 25, "condition": "sunny"}
-
-def get_news(topic):
-    return {"news": "The weather in Paris is sunny and 25 degrees Celsius."}
-
-prompt = Chat([
-    ("system", "You are a helpful assistant. Answer in French. Use the tools provided to answer the user's question."),
-    ("user", "Tell me about the weather in Paris."),
-    ("assistant", "{'tool': 'get_weather', 'args': {'city': 'Paris'}}"),
-    ("function", "{'temperature': 25, 'condition': 'sunny'}")
-])
-print(model(prompt, max_tokens=20, tools=[get_weather, get_news]))
+#def get_weather(city):
+#    return {"temperature": 25, "condition": "sunny"}
+#
+#def get_news(topic):
+#    return {"news": "The weather in Paris is sunny and 25 degrees Celsius."}
+#
+#prompt = Chat([
+#    ({"role": "system", "content": "You are a helpful assistant. Answer in French. Use the tools provided to answer the user's question."}),
+#    ({"role": "user", "content": "Tell me about the weather in Paris."}),
+#    ({"role": "assistant", "content": "{'tool': 'get_weather', 'args': {'city': 'Paris'}}"}),
+#    ({"role": "function", "content": "{'temperature': 25, 'condition': 'sunny'}"})
+#])
+#print(model(prompt, max_tokens=20, tools=[get_weather, get_news]))

--- a/outlines/generator.py
+++ b/outlines/generator.py
@@ -8,7 +8,6 @@ from typing import (
     Union,
 )
 
-from outlines.inputs import prompt_string_to_chat
 from outlines.models import (
     AsyncBlackBoxModel,
     BlackBoxModel,
@@ -71,7 +70,7 @@ class BlackBoxGenerator:
 
         """
         return self.model.generate(
-            process_user_prompt(prompt), self.output_type, **inference_kwargs
+            prompt, self.output_type, **inference_kwargs
         )
 
     def stream(self, prompt: Any, **inference_kwargs) -> Iterator[Any]:
@@ -91,7 +90,7 @@ class BlackBoxGenerator:
 
         """
         return self.model.generate_stream(
-            process_user_prompt(prompt), self.output_type, **inference_kwargs
+            prompt, self.output_type, **inference_kwargs
         )
 
 
@@ -140,7 +139,7 @@ class AsyncBlackBoxGenerator:
 
         """
         return await self.model.generate(
-            process_user_prompt(prompt), self.output_type, **inference_kwargs
+            prompt, self.output_type, **inference_kwargs
         )
 
     async def stream(
@@ -162,7 +161,7 @@ class AsyncBlackBoxGenerator:
 
         """
         async for chunk in self.model.generate_stream(  # pragma: no cover
-            process_user_prompt(prompt), self.output_type, **inference_kwargs
+            prompt, self.output_type, **inference_kwargs
         ):
             yield chunk
 
@@ -266,7 +265,7 @@ class SteerableGenerator:
 
         """
         return self.model.generate(
-            process_user_prompt(prompt), self.logits_processor, **inference_kwargs
+            prompt, self.logits_processor, **inference_kwargs
         )
 
     def stream(self, prompt: Any, **inference_kwargs) -> Iterator[Any]:
@@ -286,7 +285,7 @@ class SteerableGenerator:
 
         """
         return self.model.generate_stream(
-            process_user_prompt(prompt), self.logits_processor, **inference_kwargs
+            prompt, self.logits_processor, **inference_kwargs
         )
 
 
@@ -346,23 +345,3 @@ def Generator(
                 "The model argument must be an instance of "
                 "SteerableModel, BlackBoxModel or AsyncBlackBoxModel"
             )
-
-
-def process_user_prompt(prompt: Any) -> Any:
-    """Process the user-provided prompt to turn strings into `Chat` instances
-    if they contains messages. Leave all other types of prompt unchanged.
-
-    Parameters
-    ----------
-    prompt
-        The prompt provided by the user to process.
-
-    """
-    if isinstance(prompt, str):
-        prompt = prompt_string_to_chat(prompt) or prompt
-    elif isinstance(prompt, list):
-        prompt = [
-            process_user_prompt(item) if isinstance(item, str) else item
-            for item in prompt
-        ]
-    return prompt

--- a/outlines/inputs.py
+++ b/outlines/inputs.py
@@ -1,0 +1,179 @@
+import base64
+import re
+from dataclasses import dataclass
+from io import BytesIO
+from typing import List, Optional, Union, Literal
+
+from PIL import Image
+
+
+@dataclass
+class Vision:
+    """Contains the input for a vision model.
+
+    Provide an instance of this class as the `model_input` argument to a model
+    that supports vision. You can also include a `Vision` instance as a message
+    in a `Chat` object.
+
+    Parameters
+    ----------
+    prompt
+        The prompt to use to generate the response.
+    image
+        The image to use to generate the response.
+
+    """
+    prompt: str
+    image: Image.Image
+
+    def __post_init__(self):
+        image = self.image
+
+        if not image.format:
+            raise TypeError(
+                "Could not read the format of the image passed to the model."
+            )
+
+        buffer = BytesIO()
+        image.save(buffer, format=image.format)
+        self.image_str = base64.b64encode(buffer.getvalue()).decode("utf-8")
+        self.image_format = f"image/{image.format.lower()}"
+
+
+@dataclass
+class Message:
+    """Contains the input for a message as part of a `Chat` prompt.
+
+    This class is not intended to be used directly. Provide regular dicts
+    in a list to the `Chat` class instead.
+
+    Parameters
+    ----------
+    role
+        The role of the message.
+    content
+        The content of the message.
+
+    """
+    role: Literal["user", "assistant", "system"]
+    content: str
+
+    def __post_init__(self):
+        if self.role not in ["user", "assistant", "system"]:
+            raise ValueError(
+                "Invalid role. The only valid roles are 'user', 'assistant' "
+                "and 'system'."
+            )
+
+        if not isinstance(self.content, str):
+            raise ValueError("Content must be a string")
+
+
+@dataclass
+class Chat:
+    """Contains the input for a chat model.
+
+    Provide an instance of this class as the `model_input` argument to a model
+    that supports chat.
+
+    On top of `Vision` instances, the messages can be dicts with 'role' and
+    'content' keys. The role can be 'user', 'assistant', or 'system'. The content
+    must be a string.
+
+    Examples
+    --------
+    ```python
+    chat_prompt = Chat([
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Describe the image below please."},
+        Vision("Title: A beautiful sunset over a calm ocean.", image),
+    ])
+    ```
+
+    Parameters
+    ----------
+    messages
+        A list of messages.
+
+    """
+    messages: List[Union[dict, Message, Vision]]
+
+    def __post_init__(self):
+        processed_messages = []
+        for message in self.messages:
+            processed_messages.append(self._input_processing(message))
+        self.messages = processed_messages
+
+    def _input_processing(
+        self, input: Union[dict, Message, Vision]
+    ) -> Union[Message, Vision]:
+        """Process the user-provided input to return an object that can be
+        added to the message list.
+
+        """
+        if isinstance(input, dict):
+            return Message(**input)
+        elif isinstance(input, Message) or isinstance(input, Vision):
+            return input
+        else:
+            raise ValueError(
+                "Invalid message type. The only valid message types are "
+                "dict, Message and Vision."
+            )
+
+    def add(self, message: Union[dict, Message, Vision], index: int = -1):
+        """Add a message to the chat.
+
+        Parameters
+        ----------
+        message
+            Either a dict with 'role' and 'content' keys, or a `Message` or
+            `Vision` instance.
+        index
+            The index at which to insert the message. If not provided, the
+            message will be appended to the end of the list.
+
+        """
+        self.messages.insert(index, self._input_processing(message))
+
+    def remove(self, index: int = -1):
+        """Remove a message from the chat.
+
+        Parameters
+        ----------
+        index
+            The index of the message to remove. If not provided, the last
+            message will be removed.
+
+        """
+        self.messages.pop(index)
+
+    def __str__(self):
+        return "\n".join(str(message) for message in self.messages)
+
+
+def prompt_string_to_chat(prompt: str) -> Optional[Chat]:
+    """Try to convert a string to a Chat object. Nothing is returned if the
+    string does not contain any messages (if it's a regular prompt).
+
+    The string should use the following format to be recognized as a chat:
+    {% role %}content{% endrole %}
+    Where role can be 'system', 'user', or 'assistant'.
+
+    Everything outside of the messages is ignored.
+
+    Parameters
+    ----------
+    prompt
+        The prompt to convert to a `Chat` object if it contains messages.
+
+    """
+    messages = []
+    for match in re.finditer(r'{%\s*(\w+)\s*%}(.*?){%\s*end\1\s*%}', prompt, re.DOTALL):
+        role = match.group(1).lower()
+        content = match.group(2).strip()
+        if role in ["user", "assistant", "system"]:
+            messages.append({"role": role, "content": content})
+    if messages:
+        return Chat(messages) # type: ignore
+    return None

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass, field, replace
 from pydantic import BaseModel, TypeAdapter
 
 from outlines.caching import cache
-from outlines.inputs import Chat, Message
+from outlines.inputs import Chat
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.templates import Vision
 from outlines.types import JsonSchema, Regex, CFG
@@ -85,11 +85,13 @@ class OpenAITypeAdapter(ModelTypeAdapter):
 
         """
         messages = []
-        for message in model_input.messages:
-            if isinstance(message, Message):
-                messages.append(self.create_text_message(message.role, message.content))
-            elif isinstance(message, Vision):
-                messages.append(self.create_vision_message(message))
+        for role, content in model_input.messages:
+            if isinstance(content, str):
+                messages.append(self.create_text_message(role, content))
+            elif isinstance(content, Vision):
+                messages.append(self.create_vision_message(content))
+            else:
+                raise ValueError(f"Unsupported message type: {type(content)}")
         return {"messages": messages}
 
     def format_vision_model_input(self, model_input: Vision) -> dict:

--- a/outlines/templates.py
+++ b/outlines/templates.py
@@ -1,6 +1,5 @@
 """Create templates to easily build prompts."""
 
-import base64
 import functools
 import inspect
 import json
@@ -8,46 +7,15 @@ import os
 import re
 import textwrap
 from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Type, cast
 import warnings
 
 import jinja2
-from PIL import Image
 from pydantic import BaseModel
 
-
-@dataclass
-class Vision:
-    """Contains the input for a vision model.
-
-    Provide an instance of this class as the `model_input` argument to a model
-    that supports vision.
-
-    Parameters
-    ----------
-    prompt
-        The prompt to use to generate the response.
-    image
-        The image to use to generate the response.
-
-    """
-    prompt: str
-    image: Image.Image
-
-    def __post_init__(self):
-        image = self.image
-
-        if not image.format:
-            raise TypeError(
-                "Could not read the format of the image passed to the model."
-            )
-
-        buffer = BytesIO()
-        image.save(buffer, format=image.format)
-        self.image_str = base64.b64encode(buffer.getvalue()).decode("utf-8")
-        self.image_format = f"image/{image.format.lower()}"
+# for legacy purposes as Vision used to be defined here
+from outlines.inputs import Vision
 
 
 @dataclass


### PR DESCRIPTION
Description:
- Create an `inputs` module in which we put the `Vision` and `Chat` classes
- Users can initialize a `Chat` instance by providing a list of dicts and/or `Vision` instances and can later add/remove elements from it
- Dicts provided to `Chat` are turned into instances of `Message` for format validation and easier internal handling
- When the user calls a model with a string or a list of strings, we turn them into `Chat` instances with the function `prompt_string_to_chat` if they include tags such as `{% user %}`
- The type adapters of each model is responsible for handling the `Chat` input and turning it into the appropriate format (same as with `Vision`)

Should we tell the users about the `Message` class (or let it be just internal)?
Pro: some may find it more convenient to use `Message("user", "Hello there")` rather than `{"role": "user", "content": "Hello there"}`
Con: one more entity