### PR TITLE
Set add_generation_template to True in chat formatting for Transformers

### DIFF
--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -166,7 +166,8 @@ class TransformersTypeAdapter(ModelTypeAdapter):
     def format_chat_input(self, model_input: Chat) -> str:
         return self.tokenizer.apply_chat_template(
             model_input.messages,
-            tokenize=False
+            tokenize=False,
+            add_generation_prompt=True,
         )
 
     def format_output_type(


### PR DESCRIPTION
Some instruct models need the chat prompt to end with the assistant start tag, otherwise performance is degraded. By default, the parameter `add_generation_prompt` is `False`, so we need to set it to `True`.