### PR TITLE
Remove dead link to VLM example from examples index

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,7 +13,6 @@ This part of the documentation provides a few cookbooks that you can browse to g
 - [Structured Generation Workflow](structured_generation_workflow.md):
 - [Chain Of Thought (CoT)](chain_of_thought.md): Generate a series of intermediate reasoning steps using regex-structured generation.
 - [ReAct Agent](react_agent.md): Build an agent with open weights models using regex-structured generation.
-- [Vision-Language Models](atomic_caption.md): Use Outlines with vision-language models for tasks like image captioning and visual reasoning.
 - [Structured Generation from PDFs](read-pdfs.md): Use Outlines with vision-language models to read PDFs and produce structured output.
 - [Earnings reports to CSV](earnings-reports.md): Extract data from earnings reports to CSV using regex-structured generation.
 - [Receipt Digitization](receipt-digitization.md): Extract information from a picture of a receipt using structured generation.

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -72,14 +72,14 @@ For a quick start, you can find below an example of how to initialize all suppor
 
     ```python
     import outlines
-    from transformers
+    from transformers import AutoModelForCausalLM, AutoTokenizer
 
     # Define the model you want to use
     model_name = "HuggingFaceTB/SmolLM2-135M-Instruct"
 
     # Create a HuggingFace model and tokenizer
-    hf_model = transformers.AutoModelForCausalLM.from_pretrained(model_name)
-    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+    hf_model = AutoModelForCausalLM.from_pretrained(model_name)
+    hf_tokenizer = AutoTokenizer.from_pretrained(model_name)
 
     # Create an Outlines model
     model = outlines.from_transformers(hf_model, hf_tokenizer)
@@ -256,7 +256,7 @@ In the meantime, you can find below examples of using each of the five output ty
     # Generate a character
     result = model("Create a character", Character)
     print(result) # '{"name": "Aurora", "birth_date": "1990-06-15", "skills": ["Stealth", "Diplomacy"]}'
-    print(Character.model_validate_json(result);) # name=Aurora birth_date=datetime.date(1990, 6, 15) skills=['Stealth', 'Diplomacy']
+    print(Character.model_validate_json(result)) # name=Aurora birth_date=datetime.date(1990, 6, 15) skills=['Stealth', 'Diplomacy']
     ```
 
 === "Regex"


### PR DESCRIPTION
This PR removes a dead link to the VLM example from the [examples/index.md](https://github.com/dottxt-ai/outlines/blob/main/docs/examples/index.md). The original example has since been moved to the guides section, as documented in https://github.com/dottxt-ai/outlines/pull/1643.

My only open question is whether the example should still be referenced in the examples index (as a walkthrough-style example). Happy to follow the maintainers' guidance on this.