### PR TITLE
Fix broken wheel builds caused by ambiguous packaging instructions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,8 @@ repository = "https://github.com/dottxt-ai/outlines"
 file="README.md"
 content-type = "text/markdown"
 
-[tool.setuptools]
-packages = ["outlines"]
+[tool.setuptools.packages.find]
+include = ["outlines*"]
 
 [tool.setuptools.package-data]
 "outlines" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ content-type = "text/markdown"
 include = ["outlines*"]
 
 [tool.setuptools.package-data]
-"outlines" = ["py.typed"]
+"outlines" = ["py.typed", "grammars/*.lark"]
 
 [tool.setuptools_scm]
 write_to = "outlines/_version.py"


### PR DESCRIPTION
When building an outlines wheel (e.g. `python -m build .`), we see this warning:
```
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'outlines.fsm' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'outlines.fsm' is explicitly added
        to the `packages` configuration field.
```

The ambiguity of the configuration means that wheel build tools such as `pip wheel` can choose to exclude submodules (such as `outlines.fsm`) when creating the wheel. When we've been creating the wheel, we see that `outlines.fsm` -- or any other outlines python submodule -- is not packaged within the wheel.

The fix in the PR is based off the [setuptools recommendation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#package-discovery). The warnings disappear and the submodules are correctly packaged after this fix