### PR TITLE
Create our own logits processor for Xgrammar, add support for mlx

### DIFF
--- a/docs/features/advanced/backends.md
+++ b/docs/features/advanced/backends.md
@@ -47,7 +47,7 @@ As mentioned previously, selecting the structured generation backend is only app
 | **Models** | | | |
 | Transformers | ✅ | ✅ | ✅ |
 | LlamaCpp | ✅ | ✅ | ❌ |
-| MLXLM | ✅ | ✅ | ❌ |
+| MLXLM | ✅ | ✅ | ✅ |
 | **Output Types** | | | |
 | JSON Schema | ✅ | ✅ | ✅ |
 | Regex | ✅ | ✅ | ✅ |

--- a/outlines/backends/xgrammar.py
+++ b/outlines/backends/xgrammar.py
@@ -1,57 +1,109 @@
 """Backend class for XGrammar."""
 
-from typing import TYPE_CHECKING
-
 from outlines.backends.base import BaseBackend
 from outlines.models import SteerableModel
+from outlines.models.mlxlm import MLXLM
 from outlines.models.transformers import Transformers
 from outlines.processors.base_logits_processor import (
     OutlinesLogitsProcessor,
     TensorType
 )
 
-if TYPE_CHECKING:
-    from xgrammar.contrib.hf import LogitsProcessor
-
 
 class XGrammarLogitsProcessor(OutlinesLogitsProcessor):
-    """Logits processor for XGrammar.
+    """Logits processor for XGrammar."""
 
-    This class wraps the `xgr.contrib.hf.LogitsProcessor` class and adds
-    a `reset` method to reset the logits processor for a new generation.
-
-    """
-
-    def __init__(self, compiled_grammar: str):
+    def __init__(self, compiled_grammar: str, tensor_library_name: str,):
         """
         Parameters
         ----------
         compiled_grammar: str
             The compiled grammar to use to create the logits processor.
+        tensor_library_name: str
+            The name of the tensor library used by the model
 
         """
         import xgrammar as xgr
 
         self.xgr = xgr
+        self.is_first_token = True
         self.compiled_grammar = compiled_grammar
-        self.xgrammar_logits_processor = None
-        super().__init__("torch")
+        self.tensor_library_name = tensor_library_name
+        super().__init__(tensor_library_name)
 
     def reset(self):
-        """Reset the logits processor for a new generation."""
-        self.xgrammar_logits_processor = None
+        """Ensure self._setup is called again for the next generation."""
+        self.is_first_token = True
 
-    def process_logits(self, input_ids: TensorType, logits: TensorType) -> TensorType:
-        """Bias the logits."""
-        if self.xgrammar_logits_processor is None:
-            self.xgrammar_logits_processor = self.xgr.contrib.hf.LogitsProcessor(
-                self.compiled_grammar
+    def _setup(self, batch_size: int, vocab_size: int) -> None:
+        """Setup the logits processor for a new generation."""
+        if self.tensor_library_name == "torch":
+            self._bias_logits = self._bias_logits_torch
+        elif self.tensor_library_name == "mlx":
+            self._bias_logits = self._bias_logits_mlx
+        else: # pragma: no cover
+            raise ValueError(
+                f"Unsupported tensor library: {self.tensor_library_name}"
             )
-        return self.xgrammar_logits_processor(input_ids, logits) # type: ignore
+
+        self._matchers = [
+            self.xgr.GrammarMatcher(self.compiled_grammar)
+            for _ in range(batch_size)
+        ]
+        self._bitmask = self.xgr.allocate_token_bitmask(batch_size, vocab_size)
+
+    def _bias_logits_torch(
+        self, input_ids: TensorType, logits: TensorType
+    ) -> TensorType:
+        """Bias the logits for Torch tensors."""
+        for i in range(self.tensor_adapter.shape(input_ids)[0]):
+            if not self._matchers[i].is_terminated():
+                self._matchers[i].fill_next_token_bitmask(self._bitmask, i)
+
+        self.xgr.apply_token_bitmask_inplace(logits, self._bitmask)
+
+        return logits
+
+    def _bias_logits_mlx( # pragma: no cover
+        self, input_ids: TensorType, logits: TensorType
+    ) -> TensorType:
+        """Bias the logits for MLX tensors."""
+        import mlx.core as mx
+        from xgrammar.kernels.apply_token_bitmask_mlx import apply_token_bitmask_mlx
+
+        for i in range(self.tensor_adapter.shape(input_ids)[0]):
+            if not self._matchers[i].is_terminated():
+                self._matchers[i].fill_next_token_bitmask(self._bitmask, i)
+
+        biased_logits = apply_token_bitmask_mlx(
+            mx.array(self._bitmask.numpy()), logits, self.tensor_adapter.shape(logits)[1]
+        )
+
+        return biased_logits
+
+    def process_logits(
+        self, input_ids: TensorType, logits: TensorType
+    ) -> TensorType:
+        """Use the XGrammar matchers to bias the logits."""
+        batch_size = self.tensor_adapter.shape(input_ids)[0]
+        vocab_size = self.tensor_adapter.shape(logits)[1]
+
+        if self.is_first_token:
+            self._setup(batch_size, vocab_size)
+            self.is_first_token = False
+        else:
+            for i in range(batch_size):
+                if not self._matchers[i].is_terminated():
+                    last_token_id = self.tensor_adapter.to_scalar(
+                        input_ids[i][-1] # type: ignore
+                    )
+                    assert self._matchers[i].accept_token(last_token_id)
+
+        return self._bias_logits(input_ids, logits)
 
 
 class XGrammarBackend(BaseBackend):
-    """Backend for XGRammar."""
+    """Backend for XGrammar."""
 
     def __init__(self, model: SteerableModel):
         """
@@ -62,25 +114,27 @@ class XGrammarBackend(BaseBackend):
 
         """
         import xgrammar as xgr
-        from transformers import AutoConfig
 
-        if not isinstance(model, Transformers):
+        if isinstance(model, Transformers):
+            tokenizer = model.hf_tokenizer
+        elif isinstance(model, MLXLM):
+            tokenizer = model.mlx_tokenizer._tokenizer
+        else: # pragma: no cover
             raise ValueError(
-                "The xgrammar backend only supports Transformers models"
+                "The xgrammar backend only supports Transformers and "
+                + "MLXLM models"
             )
 
-        vocab_size = AutoConfig.from_pretrained(
-            model.model.config._name_or_path
-        ).vocab_size
         tokenizer_info = xgr.TokenizerInfo.from_huggingface(
-            model.hf_tokenizer,
-            vocab_size=vocab_size
+            tokenizer,
+            vocab_size=len(tokenizer.get_vocab())
         )
         self.grammar_compiler = xgr.GrammarCompiler(tokenizer_info)
+        self.tensor_library_name = model.tensor_library_name
 
     def get_json_schema_logits_processor(
         self, json_schema: str
-    ) -> "LogitsProcessor":
+    ) -> XGrammarLogitsProcessor:
         """Create a logits processor from a JSON schema.
 
         Parameters
@@ -97,9 +151,14 @@ class XGrammarBackend(BaseBackend):
         compiled_grammar = self.grammar_compiler.compile_json_schema(
             json_schema
         )
-        return XGrammarLogitsProcessor(compiled_grammar)
+        return XGrammarLogitsProcessor(
+            compiled_grammar,
+            self.tensor_library_name
+        )
 
-    def get_regex_logits_processor(self, regex: str) -> "LogitsProcessor":
+    def get_regex_logits_processor(
+        self, regex: str
+    ) -> XGrammarLogitsProcessor:
         """Create a logits processor from a regex.
 
         Parameters
@@ -114,9 +173,14 @@ class XGrammarBackend(BaseBackend):
 
         """
         compiled_grammar = self.grammar_compiler.compile_regex(regex)
-        return XGrammarLogitsProcessor(compiled_grammar)
+        return XGrammarLogitsProcessor(
+            compiled_grammar,
+            self.tensor_library_name
+        )
 
-    def get_cfg_logits_processor(self, grammar: str) -> "LogitsProcessor":
+    def get_cfg_logits_processor(
+        self, grammar: str
+    ) -> XGrammarLogitsProcessor:
         """Create a logits processor from a context-free grammar.
 
         Parameters
@@ -131,4 +195,7 @@ class XGrammarBackend(BaseBackend):
 
         """
         compiled_grammar = self.grammar_compiler.compile_grammar(grammar)
-        return XGrammarLogitsProcessor(compiled_grammar)
+        return XGrammarLogitsProcessor(
+            compiled_grammar,
+            self.tensor_library_name
+        )

--- a/tests/backends/test_xgrammar.py
+++ b/tests/backends/test_xgrammar.py
@@ -90,6 +90,6 @@ def test_xgrammar_backend(model_transformers, json_schema, regex, cfg):
 def test_xgrammar_backend_invalid_model(model_llamacpp):
     with pytest.raises(
         ValueError,
-        match="The xgrammar backend only supports Transformers models",
+        match="The xgrammar backend only supports Transformers and MLXLM models",
     ):
         XGrammarBackend(model_llamacpp)


### PR DESCRIPTION
Closes #1698 

This is a dependency for adding support for thinking models (#1627) as we will need to add some custom logic to the logits prorcessor, so we must create our own.

The PR adds supports for `mlx` but not for `numpy` (so the `LlamaCpp` model is not supported) as it does not seem that Xgrammar currently supports `numpy` tensors. If that changes in the future or if we find a way to make it work, it should be easy to add as the logits processor already has the right architecture for it.

PS: coverage check is still broken, there's an issue for that we should work on at some point