### PR TITLE
Fix bug related to the device of the bitmasks and logits for torch

### DIFF
--- a/outlines/backends/llguidance.py
+++ b/outlines/backends/llguidance.py
@@ -115,8 +115,17 @@ class LLGuidanceLogitsProcessor(OutlinesLogitsProcessor):
 
         for i in range(self.tensor_adapter.shape(input_ids)[0]):
             llguidance.torch.fill_next_token_bitmask(self.ll_matchers[i], self.bitmask, i)
+            self.bitmask = self.tensor_adapter.to_device(
+                self.bitmask,
+                self.tensor_adapter.get_device(logits)
+            )
             llguidance.torch.apply_token_bitmask_inplace(
-                logits[i], self.bitmask[i] # type: ignore
+                logits[i], # type: ignore
+                self.bitmask[i]
+            )
+            self.bitmask = self.tensor_adapter.to_device(
+                self.bitmask,
+                "cpu"
             )
 
         return logits

--- a/outlines/backends/xgrammar.py
+++ b/outlines/backends/xgrammar.py
@@ -60,7 +60,15 @@ class XGrammarLogitsProcessor(OutlinesLogitsProcessor):
             if not self._matchers[i].is_terminated():
                 self._matchers[i].fill_next_token_bitmask(self._bitmask, i)
 
+        self._bitmask = self.tensor_adapter.to_device(
+            self._bitmask,
+            self.tensor_adapter.get_device(logits)
+        )
         self.xgr.apply_token_bitmask_inplace(logits, self._bitmask)
+        self._bitmask = self.tensor_adapter.to_device(
+            self._bitmask,
+            "cpu"
+        )
 
         return logits
 


### PR DESCRIPTION
Edited 2025-08-07

Closes #1710 

The problem described in the issue concerned the `Transformers` models using `torch` tensors and running on a non-cpu device. The issue was a mismatch between the location of the logits and that of the bitmask.

The solution is to properly handle the device location of the bitmasks before calling the `apply_token_bitmask_inplace` functions.