### PR TITLE
Fix a bug in OutlinesCore backend about advancing when in final state

### DIFF
--- a/outlines/backends/outlines_core.py
+++ b/outlines/backends/outlines_core.py
@@ -179,7 +179,13 @@ class OutlinesCoreLogitsProcessor(OutlinesLogitsProcessor):
         else:
             for i in range(batch_size):
                 last_token_id = self.tensor_adapter.to_scalar(input_ids[i][-1]) # type: ignore
-                if not self._guides[i].is_finished():
+                # This circumvents issue #227 in outlines_core
+                # Ideally, we would be able to advance all the times as the final
+                # state would accept the eos token leading to itself
+                if (
+                    not self._guides[i].is_finished()
+                    or self._guides[i].accepts_tokens([last_token_id])
+                ):
                     self._guides[i].advance(
                         token_id=last_token_id,
                         return_tokens=False


### PR DESCRIPTION
Deals with the consequences of an [issue in outlines-core](https://github.com/dottxt-ai/outlines-core/issues/227)

As described in the linked issue, there is a bug in outlines-core in which, when in a final position, the `eos_token_id` is returned by the `get_tokens` method, but then causes an error if we try to advance through the guide with it! To avoid this problem, the outlines implementation used to simply check whether the current state is final, and stops advancing through the guide if that's the case. That causes another problem in case there are several different final states in the index, as we were not advancing through the guide even though a token leading to another final state was generated.

The fix proposed here is to check whether the token last generated is accepted by the `accepts_tokens` method to avoid advancing if the `eos_token_id` has been generated (as before), but do advance through the guide in all other cases, especially when the token generated leads to a different final state.