### PR TITLE
Fix correct handling of chat multimodal inputs in TransformersMM class

### DIFF
--- a/docs/features/models/transformers_multimodal.md
+++ b/docs/features/models/transformers_multimodal.md
@@ -82,7 +82,7 @@ print(Animal.model_validate_json(result)) # specie=cat, color=white, weight=4
 
 
 ### Chat
-The `Chat` interface offers a more convenient way to work with multimodal inputs. You don't need to manually add asset tags like `<image>`. The model's HF processor handles the chat templating and asset placement for you automatically. 
+The `Chat` interface offers a more convenient way to work with multimodal inputs. You don't need to manually add asset tags like `<image>`. The model's HF processor handles the chat templating and asset placement for you automatically.
 To do so, call the model with a `Chat` instance using a multimodal chat format. Assets must be pre-processed as `outlines.inputs.{Image, Audio, Video}` format, and only `image`, `video`, and `audio` types are supported.
 
 For instance:
@@ -107,7 +107,7 @@ def get_image_from_url(image_url):
     image = PILImage.open(img_byte_stream).convert("RGB")
     image.format = "PNG"
     return image
-    
+
 # Create the model
 model = outlines.from_transformers(
     AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs),
@@ -162,7 +162,7 @@ def get_image_from_url(image_url):
     image = PILImage.open(img_byte_stream).convert("RGB")
     image.format = "PNG"
     return image
-    
+
 # Create the model
 model = outlines.from_transformers(
     AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs),

--- a/docs/features/models/transformers_multimodal.md
+++ b/docs/features/models/transformers_multimodal.md
@@ -10,18 +10,18 @@ The Outlines `TransformersMultiModal` model inherits from `Transformers` and sha
 
 To load the model, you can use the `from_transformers` function. It takes 2 arguments:
 
-- `model`: a `transformers` model (created with `AutoModelForCausalLM` for instance)
+- `model`: a `transformers` model (created with `AutoModelForImageTextToText` for instance)
 - `tokenizer_or_processor`: a `transformers` processor (created with `AutoProcessor` for instance, it must be an instance of `ProcessorMixin`)
 
 For instance:
 
 ```python
 import outlines
-from transformers import AutoModelForCausalLM, AutoProcessor
+from transformers import AutoModelForImageTextToText, AutoProcessor
 
 # Create the transformers model and processor
-hf_model = AutoModelForCausalLM.from_pretrained("microsoft/Phi-3-mini-4k-instruct")
-hf_processor = AutoProcessor.from_pretrained("microsoft/Phi-3-mini-4k-instruct")
+hf_model = AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct")
+hf_processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct")
 
 # Create the Outlines model
 model = outlines.from_transformers(hf_model, hf_processor)
@@ -76,10 +76,133 @@ result = model(
 print(result) # '{"specie": "cat", "color": "white", "weight": 4}'
 print(Animal.model_validate_json(result)) # specie=cat, color=white, weight=4
 ```
+!!! Warning
 
-The `TransformersMultiModal` model supports batch generation. To use it, invoke the `batch` method with a list of lists. You will receive as a result a list of completions.
+    Make sure your prompt contains the tags expected by your processor to correctly inject the assets in the prompt. For some vision multimodal models for instance, you need to add as many `<image>` tags in your prompt as there are image assets included in your model input. `Chat` method, instead, does not require this step.
+
+
+### Chat
+The `Chat` interface offers a more convenient way to work with multimodal inputs. You don't need to manually add asset tags like `<image>`. The model's HF processor handles the chat templating and asset placement for you automatically. 
+To do so, call the model with a `Chat` instance using a multimodal chat format. Assets must be pre-processed as `outlines.inputs.{Image, Audio, Video}` format, and only `image`, `video`, and `audio` types are supported.
 
 For instance:
+
+```python
+import outlines
+from outlines.inputs import Chat, Image
+from transformers import AutoModelForImageTextToText, AutoProcessor
+from PIL import Image as PILImage
+from io import BytesIO
+from urllib.request import urlopen
+import torch
+
+model_kwargs = {
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+        "device_map": "auto",
+    }
+
+def get_image_from_url(image_url):
+    img_byte_stream = BytesIO(urlopen(image_url).read())
+    image = PILImage.open(img_byte_stream).convert("RGB")
+    image.format = "PNG"
+    return image
+    
+# Create the model
+model = outlines.from_transformers(
+    AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs),
+    AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs)
+)
+
+IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg"
+
+# Create the chat mutimodal input
+prompt = Chat([
+    {
+        "role": "user",
+        "content": [
+            {"type": "image", "image": Image(get_image_from_url(IMAGE_URL))},
+            {"type": "text", "text": "Describe the image in few words."}
+        ],
+    }
+])
+
+# Call the model to generate a response
+response = model(prompt, max_new_tokens=50)
+print(response) # 'A Siamese cat with blue eyes is sitting on a cat tree, looking alert and curious.'
+```
+
+### Batching
+The `TransformersMultiModal` model supports batching through the `batch` method. To use it, provide a list of prompts (using the formats described above) to the `batch` method. You will receive as a result a list of completions.
+
+An example using the Chat format:
+
+```python
+import outlines
+from outlines.inputs import Chat, Image
+from transformers import AutoModelForImageTextToText, AutoProcessor
+from PIL import Image as PILImage
+from io import BytesIO
+from urllib.request import urlopen
+import torch
+from pydantic import BaseModel
+
+model_kwargs = {
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+        "device_map": "auto",
+    }
+
+class Animal(BaseModel):
+    animal: str
+    color: str
+
+def get_image_from_url(image_url):
+    img_byte_stream = BytesIO(urlopen(image_url).read())
+    image = PILImage.open(img_byte_stream).convert("RGB")
+    image.format = "PNG"
+    return image
+    
+# Create the model
+model = outlines.from_transformers(
+    AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs),
+    AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs)
+)
+
+IMAGE_URL_1 = "https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg"
+IMAGE_URL_2 = "https://upload.wikimedia.org/wikipedia/commons/a/af/Golden_retriever_eating_pigs_foot.jpg"
+
+# Create the chat mutimodal messages
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe the image in few words."},
+            {"type": "image", "image": Image(get_image_from_url(IMAGE_URL_1))},
+        ],
+    },
+]
+
+messages_2 = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe the image in few words."},
+            {"type": "image", "image": Image(get_image_from_url(IMAGE_URL_2))},
+        ],
+    },
+]
+
+prompts = [Chat(messages), Chat(messages_2)]
+
+# Call the model to generate a response
+responses = model.batch(prompts, output_type=Animal, max_new_tokens=100)
+print(responses) # ['{ "animal": "cat", "color": "white and gray" }', '{ "animal": "dog", "color": "white" }']
+print([Animal.model_validate_json(i) for i in responses]) # [Animal(animal='cat', color='white and gray'), Animal(animal='dog', color='white')]
+```
+
+
+An example using a list of lists with tag assets:
 
 ```python
 from io import BytesIO
@@ -119,59 +242,3 @@ result = model.batch(
 )
 print(result) # ['The image shows a cat', 'The image shows an astronaut']
 ```
-
-### Chat
-You can use chat inputs with the `TransformersMultiModal` model. To do so, call the model with a `Chat` instance. 
-
-For instance:
-
-```python
-import outlines
-from outlines.inputs import Chat, Image
-from transformers import AutoModelForImageTextToText, AutoProcessor
-from PIL import Image as PILImage
-from io import BytesIO
-from urllib.request import urlopen
-import torch
-
-model_kwargs = {
-        "torch_dtype": torch.bfloat16,
-        "attn_implementation": "flash_attention_2",
-        "device_map": "auto",
-    }
-
-def get_image_from_url(image_url):
-    img_byte_stream = BytesIO(urlopen(image_url).read())
-    image = PILImage.open(img_byte_stream).convert("RGB")
-    image.format = "PNG"
-    image.save("image.png")
-    return image
-    
-# Create the model
-model = outlines.from_transformers(
-    AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs),
-    AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", **model_kwargs)
-)
-
-IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/2/25/Siam_lilacpoint.jpg"
-
-# Create the chat mutimodal input
-prompt = Chat([
-    {
-        "role": "user",
-        "content": [
-            {"type": "image", "image": Image(get_image_from_url(IMAGE_URL))},
-            {"type": "text", "text": "Describe the image in few words."}
-        ],
-    }
-])
-
-# Call the model to generate a response
-response = model(prompt, max_new_tokens=50)
-print(response) # 'A Siamese cat with blue eyes is sitting on a cat tree, looking alert and curious.'
-```
-
-
-!!! Warning
-
-    Make sure your prompt contains the tags expected by your processor to correctly inject the assets in the prompt. For some vision multimodal models for instance, you need to add as many `<image>` tags in your prompt as there are image assets included in your model input.

--- a/outlines/inputs.py
+++ b/outlines/inputs.py
@@ -81,8 +81,8 @@ class Chat:
     Each message contained in the messages list must be a dict with 'role' and
     'content' keys. The role can be 'user', 'assistant', or 'system'. The content
     supports either:
-    - a text string, or
-    - a list containing text and assets (e.g., ["Describe...", Image(...)]), or
+    - a text string,
+    - a list containing text and assets (e.g., ["Describe...", Image(...)]),
     - only for HuggingFace transformers models, a list of dict items with explicit types (e.g.,
       [{"type": "text", "text": "Describe..."}, {"type": "image", "image": Image(...)}])
 

--- a/outlines/inputs.py
+++ b/outlines/inputs.py
@@ -83,7 +83,7 @@ class Chat:
     supports either:
     - a text string, or
     - a list containing text and assets (e.g., ["Describe...", Image(...)]), or
-    - a list of dict items with explicit types (e.g.,
+    - only for HuggingFace transformers models, a list of dict items with explicit types (e.g.,
       [{"type": "text", "text": "Describe..."}, {"type": "image", "image": Image(...)}])
 
     Examples

--- a/outlines/inputs.py
+++ b/outlines/inputs.py
@@ -80,8 +80,11 @@ class Chat:
 
     Each message contained in the messages list must be a dict with 'role' and
     'content' keys. The role can be 'user', 'assistant', or 'system'. The content
-    can be a string or a list containing a str and assets (images, videos,
-    audios, etc.) in the case of multimodal models.
+    supports either:
+    - a text string, or
+    - a list containing text and assets (e.g., ["Describe...", Image(...)]), or
+    - a list of dict items with explicit types (e.g.,
+      [{"type": "text", "text": "Describe..."}, {"type": "image", "image": Image(...)}])
 
     Examples
     --------
@@ -95,7 +98,7 @@ class Chat:
     chat_prompt.add_user_message(["Describe the image below", Image(image)])
 
     # Add as an assistant message the response from the model.
-    chat_prompt.add_assistant_message("The is a black cat sitting on a couch.")
+    chat_prompt.add_assistant_message("There is a black cat sitting on a couch.")
     ```
 
     Parameters

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -472,20 +472,29 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
         else:
             raise ValueError(
                 f"Invalid content type: {type(content)}. "
-                "The content must be a string or a list containing text and assets "
-                "or a list of dict items with explicit types."
+                + "The content must be a string or a list containing text and assets "
+                + "or a list of dict items with explicit types."
             )
 
     def _extract_assets_from_content(self, content: list) -> list:
         """Process a list of dict items."""
         assets = []
+
         for item in content:
+            if len(item) > 2:
+                raise ValueError(
+                    f"Found item with multiple keys: {item}. "
+                    + "Each item in the content list must be a dictionary with a 'type' key and a single asset key. "
+                    + "To include multiple assets, use separate dictionary items. "
+                    + "For example: [{{'type': 'image', 'image': image1}}, {{'type': 'image', 'image': image2}}]. "
+                )
+
             if "type" not in item:
                 raise ValueError(
                     "Each item in the content list must be a dictionary with a 'type' key. "
-                    "Valid types are 'text', 'image', 'video', or 'audio'. "
-                    f"For instance {{'type': 'text', 'text': 'your message'}}. "
-                    f"Found item without 'type' key: {item}"
+                    + "Valid types are 'text', 'image', 'video', or 'audio'. "
+                    + "For instance {{'type': 'text', 'text': 'your message'}}. "
+                    + f"Found item without 'type' key: {item}"
                 )
             if item["type"] == "text":
                 continue
@@ -494,7 +503,7 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
                 if asset_key not in item:
                     raise ValueError(
                         f"Item with type '{asset_key}' must contain a '{asset_key}' key. "
-                        f"Found item: {item}"
+                        + f"Found item: {item}"
                     )
                 if isinstance(item[asset_key], (Image, Video, Audio)):
                     assets.append(item[asset_key])

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -432,10 +432,6 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
 
     @format_input.register(Chat)
     def format_chat_input(self, model_input: Chat) -> dict:
-        SUPPORTED_ASSETS = {
-            "type": ["image", "video", "audio"],
-            "class": (Image, Video, Audio)
-        }
         messages = model_input.messages
         assets = []
 
@@ -445,18 +441,18 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
                 for item in message["content"]:
                     if item["type"] == "text":
                         continue
-                    elif item["type"] in SUPPORTED_ASSETS['type']:
+                    elif item["type"] in ["image", "video", "audio"]:
                         asset_key = item["type"]
-                        if isinstance(item[asset_key], SUPPORTED_ASSETS['class']):
+                        if isinstance(item[asset_key], (Image, Video, Audio)):
                             assets.append(item[asset_key])
                         else:
                             raise ValueError(
-                                f"Assets must be of type {SUPPORTED_ASSETS['class']}. "
+                                "Assets must be of type `Image`, `Video` or `Audio`. "
                                 + f"Unsupported asset type: {asset_key}"
                             )
                     else:
                         raise ValueError(
-                            f"Content must be 'text', {SUPPORTED_ASSETS['type']}. "
+                            "Content must be 'text', 'image', 'video' or 'audio'. "
                             + f"Unsupported content type: {item['type']}")
 
         formatted_prompt = self.tokenizer.apply_chat_template(
@@ -474,7 +470,7 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
 
         if not assets:  # handle empty assets case
             return {"text": prompt}
-        
+
         asset_types = set(type(asset) for asset in assets)
         if len(asset_types) > 1:
             raise ValueError(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -445,9 +445,9 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
                 for item in message["content"]:
                     if item["type"] == "text":
                         continue
-                    elif item["type"] in SUPPORTED_ASSETS["type"]:
+                    elif item["type"] in SUPPORTED_ASSETS['type']:
                         asset_key = item["type"]
-                        if isinstance(item[asset_key], SUPPORTED_ASSETS["class"]):
+                        if isinstance(item[asset_key], SUPPORTED_ASSETS['class']):
                             assets.append(item[asset_key])
                         else:
                             raise ValueError(
@@ -456,7 +456,7 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
                             )
                     else:
                         raise ValueError(
-                            f"Content must be 'text', {SUPPORTED_ASSETS["type"]}. "
+                            f"Content must be 'text', {SUPPORTED_ASSETS['type']}. "
                             + f"Unsupported content type: {item['type']}")
 
         formatted_prompt = self.tokenizer.apply_chat_template(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -430,33 +430,6 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
             + "model or a `Chat` instance."
         )
 
-    @format_input.register(dict)
-    def format_dict_input(self, model_input: dict) -> dict:
-        warnings.warn("""
-            Providing the input as a dict is deprecated. Support for this will
-            be removed in the v1.2.0 release of Outlines. Use a list containing
-            a text prompt and assets (`Image`, `Audio` or `Video` instances)
-            instead.
-            For instance:
-            ```python
-            from outlines import Image
-            model = from_transformers(mymodel, myprocessor)
-            response = model([
-                "A beautiful image of a cat",
-                Image(my_image),
-            ])
-            ```
-            """,
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if "text" not in model_input:
-            raise ValueError(
-                "The input must contain the 'text' key along with the other "
-                + "keys required by your processor."
-            )
-        return model_input
-
     @format_input.register(Chat)
     def format_chat_input(self, model_input: Chat) -> dict:
         # we need to separate the assets from the messages

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -481,6 +481,9 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
         prompt = model_input[0]
         assets = model_input[1:]
 
+        if not assets:  # handle empty assets case
+            return {"text": prompt}
+        
         asset_types = set(type(asset) for asset in assets)
         if len(asset_types) > 1:
             raise ValueError(

--- a/tests/models/test_transformers_multimodal.py
+++ b/tests/models/test_transformers_multimodal.py
@@ -43,8 +43,6 @@ def model():
         LlavaForConditionalGeneration.from_pretrained(TEST_MODEL),
         AutoProcessor.from_pretrained(TEST_MODEL),
     )
-    chat_template = '{% for message in messages %}{{ message.role }}: {{ message.content }}{% endfor %}'
-    model.type_adapter.tokenizer.chat_template = chat_template
 
     return model
 
@@ -100,8 +98,8 @@ def test_transformers_multimodal_chat(model, image):
             {
                 "role": "user",
                 "content": [
-                    "Describe this image in one sentence:<image>",
-                    Image(image),
+                    {"type": "text", "text": "What's on this image?"},
+                    {"type": "image", "image": Image(images[0])},
                 ],
             },
         ]),
@@ -221,8 +219,8 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        "Describe this image in one sentence:<image>",
-                        Image(image),
+                        {"type": "text", "text": "What's on this image?"},
+                        {"type": "image", "image": Image(images[0])},
                     ],
                 },
             ]),
@@ -231,8 +229,8 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        "Describe this image in one sentence:<image>",
-                        Image(image),
+                        {"type": "text", "text": "What's on this image?"},
+                        {"type": "image", "image": Image(images[1])},
                     ],
                 },
             ]),
@@ -241,16 +239,3 @@ def test_transformers_multimodal_batch(model, image):
     )
     assert isinstance(result, list)
     assert len(result) == 2
-
-
-def test_transformers_multimodal_deprecated_input_type(model, image):
-    with pytest.warns(DeprecationWarning):
-        result = model.generate(
-            {
-                "text": "<image>Describe this image in one sentence:",
-                "image": image,
-            },
-            None,
-            max_new_tokens=2,
-        )
-        assert isinstance(result, str)

--- a/tests/models/test_transformers_multimodal.py
+++ b/tests/models/test_transformers_multimodal.py
@@ -98,7 +98,7 @@ def test_transformers_multimodal_chat(model, image):
             {
                 "role": "user",
                 "content": [
-                    "What's on this image?",
+                    "Describe this image in one sentence:",
                     Image(image),
                 ],
             },
@@ -113,7 +113,7 @@ def test_transformers_multimodal_chat(model, image):
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "What's on this image?"},
+                    {"type": "text", "text": "Describe this image in one sentence:"},
                     {"type": "image", "image": Image(image)},
                 ],
             },
@@ -234,7 +234,7 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        "What's on this image?",
+                        "Describe this image in one sentence:",
                         Image(image),
                     ],
                 },
@@ -244,7 +244,7 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        "What's on this image?",
+                        "Describe this image in one sentence:",
                         Image(image),
                     ],
                 },
@@ -262,7 +262,7 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        {"type": "text", "text": "What's on this image?"},
+                        {"type": "text", "text": "Describe this image in one sentence:"},
                         {"type": "image", "image": Image(image)},
                     ],
                 },
@@ -272,7 +272,7 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
-                        {"type": "text", "text": "What's on this image?"},
+                        {"type": "text", "text": "Describe this image in one sentence:"},
                         {"type": "image", "image": Image(image)},
                     ],
                 },

--- a/tests/models/test_transformers_multimodal.py
+++ b/tests/models/test_transformers_multimodal.py
@@ -98,8 +98,23 @@ def test_transformers_multimodal_chat(model, image):
             {
                 "role": "user",
                 "content": [
+                    "What's on this image?",
+                    Image(image),
+                ],
+            },
+        ]),
+        max_new_tokens=2,
+    )
+    assert isinstance(result, str)
+
+    result = model(
+        Chat(messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {
+                "role": "user",
+                "content": [
                     {"type": "text", "text": "What's on this image?"},
-                    {"type": "image", "image": Image(images[0])},
+                    {"type": "image", "image": Image(image)},
                 ],
             },
         ]),
@@ -219,8 +234,36 @@ def test_transformers_multimodal_batch(model, image):
                 {
                     "role": "user",
                     "content": [
+                        "What's on this image?",
+                        Image(image),
+                    ],
+                },
+            ]),
+            Chat(messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": [
+                        "What's on this image?",
+                        Image(image),
+                    ],
+                },
+            ]),
+        ],
+        max_new_tokens=2,
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    result = model.batch(
+        [
+            Chat(messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": [
                         {"type": "text", "text": "What's on this image?"},
-                        {"type": "image", "image": Image(images[0])},
+                        {"type": "image", "image": Image(image)},
                     ],
                 },
             ]),
@@ -230,7 +273,7 @@ def test_transformers_multimodal_batch(model, image):
                     "role": "user",
                     "content": [
                         {"type": "text", "text": "What's on this image?"},
-                        {"type": "image", "image": Image(images[1])},
+                        {"type": "image", "image": Image(image)},
                     ],
                 },
             ]),

--- a/tests/models/test_transformers_multimodal_type_adapter.py
+++ b/tests/models/test_transformers_multimodal_type_adapter.py
@@ -81,14 +81,14 @@ def test_transformers_multimodal_type_adapter_format_input_empty_assets(adapter)
 def test_transformers_multimodal_type_adapter_format_input_chat_invalid_asset_type(adapter, image):
     class MockAsset:
         pass
-    
+
     chat_prompt = Chat(messages=[
         {"role": "user", "content": [
             {"type": "text", "text": "Hello"},
             {"type": "image", "image": MockAsset()}  # Wrong type
         ]}
     ])
-    
+
     with pytest.raises(ValueError, match="Assets must be of type"):
         adapter.format_input(chat_prompt)
 
@@ -100,7 +100,7 @@ def test_transformers_multimodal_type_adapter_format_input_chat_unsupported_cont
             {"type": "unsupported", "data": "some_data"}  # Unsupported type
         ]}
     ])
-    
+
     with pytest.raises(ValueError, match="Content must be 'text'"):
         adapter.format_input(chat_prompt)
 

--- a/tests/models/test_transformers_multimodal_type_adapter.py
+++ b/tests/models/test_transformers_multimodal_type_adapter.py
@@ -73,6 +73,38 @@ def test_transformers_multimodal_type_adapter_format_input(adapter, image):
     assert result["images"][0] == image_asset.image
 
 
+def test_transformers_multimodal_type_adapter_format_input_empty_assets(adapter):
+    result = adapter.format_input(["Just text prompt"])
+    assert result == {"text": "Just text prompt"}
+
+
+def test_transformers_multimodal_type_adapter_format_input_chat_invalid_asset_type(adapter, image):
+    class MockAsset:
+        pass
+    
+    chat_prompt = Chat(messages=[
+        {"role": "user", "content": [
+            {"type": "text", "text": "Hello"},
+            {"type": "image", "image": MockAsset()}  # Wrong type
+        ]}
+    ])
+    
+    with pytest.raises(ValueError, match="Assets must be of type"):
+        adapter.format_input(chat_prompt)
+
+
+def test_transformers_multimodal_type_adapter_format_input_chat_unsupported_content_type(adapter):
+    chat_prompt = Chat(messages=[
+        {"role": "user", "content": [
+            {"type": "text", "text": "Hello"},
+            {"type": "unsupported", "data": "some_data"}  # Unsupported type
+        ]}
+    ])
+    
+    with pytest.raises(ValueError, match="Content must be 'text'"):
+        adapter.format_input(chat_prompt)
+
+
 def test_transformers_multimodal_type_adapter_format_output_type(
     adapter, logits_processor
 ):

--- a/tests/models/test_transformers_multimodal_type_adapter.py
+++ b/tests/models/test_transformers_multimodal_type_adapter.py
@@ -170,3 +170,32 @@ def test_transformers_multimodal_type_adapter_format_input_chat_missing_type_key
 
     with pytest.raises(ValueError, match="Each item in the content list must be a dictionary with a 'type' key"):
         adapter.format_input(chat_prompt)
+
+
+def test_transformers_multimodal_type_adapter_format_input_invalid_content_type(adapter):
+    chat_prompt = Chat(messages=[
+        {"role": "user", "content": 42}  # Invalid content type (integer)
+    ])
+
+    with pytest.raises(ValueError, match="Invalid content type"):
+        adapter.format_input(chat_prompt)
+
+    # Test with another invalid type
+    chat_prompt = Chat(messages=[
+        {"role": "user", "content": {"invalid": "dict"}}  # Invalid content type (dict not in list)
+    ])
+
+    with pytest.raises(ValueError, match="Invalid content type"):
+        adapter.format_input(chat_prompt)
+
+
+def test_transformers_multimodal_type_adapter_format_asset_for_template_invalid_type(adapter):
+    class MockUnsupportedAsset:
+        pass
+
+    # This test requires accessing the private method directly since the error
+    # would normally be caught earlier in the validation chain
+    unsupported_asset = MockUnsupportedAsset()
+
+    with pytest.raises(ValueError, match="Assets must be of type `Image`, `Video` or `Audio`"):
+        adapter._format_asset_for_template(unsupported_asset)

--- a/tests/models/test_transformers_multimodal_type_adapter.py
+++ b/tests/models/test_transformers_multimodal_type_adapter.py
@@ -63,7 +63,7 @@ def test_transformers_multimodal_type_adapter_format_input(adapter, image):
 
     chat_prompt = Chat(messages=[
         {"role": "system", "content": "foo"},
-        {"role": "user", "content": ["bar", image_asset]},
+        {"role": "user", "content": [{"type": "text", "text": "bar"}, {"type": "image", "image": image_asset}]},
     ])
     result = adapter.format_input(chat_prompt)
     assert isinstance(result, dict)

--- a/tests/models/test_transformers_multimodal_type_adapter.py
+++ b/tests/models/test_transformers_multimodal_type_adapter.py
@@ -43,9 +43,8 @@ def test_transformers_multimodal_type_adapter_format_input(adapter, image):
     with pytest.raises(TypeError):
         adapter.format_input("hello")
 
-    with pytest.raises(ValueError):
-        with pytest.deprecated_call():
-            adapter.format_input({"foo": "bar"})
+    with pytest.raises(TypeError):
+        adapter.format_input({"foo": "bar"})
 
     with pytest.raises(ValueError, match="All assets must be of the same type"):
         adapter.format_input(["foo", Image(image), Video("")])

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -141,6 +141,13 @@ def test_chat_add_system_message(image_input):
     assert chat.messages[0]["role"] == "system"
     assert chat.messages[0]["content"] == ["prompt", image_input]
 
+    # Add a list of dict items with explicit types
+    chat = Chat(messages=[])
+    chat.add_system_message([{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}])
+    assert len(chat.messages) == 1
+    assert chat.messages[0]["role"] == "system"
+    assert chat.messages[0]["content"] == [{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}]
+
 
 def test_add_user_message_string(image_input):
     # Add a string
@@ -157,6 +164,13 @@ def test_add_user_message_string(image_input):
     assert chat.messages[0]["role"] == "user"
     assert chat.messages[0]["content"] == ["prompt", image_input]
 
+    # Add a list of dict items with explicit types
+    chat = Chat(messages=[])
+    chat.add_user_message([{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}])
+    assert len(chat.messages) == 1
+    assert chat.messages[0]["role"] == "user"
+    assert chat.messages[0]["content"] == [{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}]
+
 
 def test_add_assistant_message_string(image_input):
     # Add a string
@@ -172,3 +186,10 @@ def test_add_assistant_message_string(image_input):
     assert len(chat.messages) == 1
     assert chat.messages[0]["role"] == "assistant"
     assert chat.messages[0]["content"] == ["prompt", image_input]
+
+    # Add a list of dict items with explicit types
+    chat = Chat(messages=[])
+    chat.add_assistant_message([{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}])
+    assert len(chat.messages) == 1
+    assert chat.messages[0]["role"] == "assistant"
+    assert chat.messages[0]["content"] == [{"type": "text", "text": "prompt"}, {"type": "image", "image": image_input}]


### PR DESCRIPTION
## Description

This PR improves the handling of **multimodal** chat inputs for TransformersMultiModal models. It addresses the challenge of correctly applying chat templates to text while integrating diverse media assets (images, audio, video).

## Changes

-   **`outlines/models/transformers.py`**:
    *   Refactored `format_chat_input` to explicitly separate multimodal assets (images, audio, video) from text messages within chat inputs;
    *   Ensured that the complete `Chat` messages are passed to `self.tokenizer.apply_chat_template` to generate text prompts with correct placeholders for multimodal content;
-   **`docs/features/models/transformers_multimodal.md`**:
    *   Updated documentation to reflect the new multimodal chat input handling capabilities;
    *   Added a new usage example demonstrating how to utilize these features.

## Call for Feedback

Looking for feedback about docs and testers regarding the Chat multimodal input handling using different models/media!