### PR TITLE
Draft add support for tools

### DIFF
--- a/outlines/generator.py
+++ b/outlines/generator.py
@@ -21,6 +21,8 @@ from outlines.backends import (
     get_regex_logits_processor,
 )
 from outlines.backends.base import LogitsProcessorType
+from outlines.outputs import Output
+from outlines.tools import get_formatted_tools, ToolsInput
 from outlines.types import CFG, JsonSchema
 from outlines.types.dsl import python_types_to_terms, to_regex
 
@@ -35,7 +37,13 @@ class BlackBoxGenerator:
     """
     output_type: Optional[Any]
 
-    def __init__(self, model: BlackBoxModel, output_type: Optional[Any]):
+    def __init__(
+        self,
+        model: BlackBoxModel,
+        output_type: Optional[Any],
+        *,
+        tools: Optional[ToolsInput] = None,
+    ):
         """
         Parameters
         ----------
@@ -47,8 +55,9 @@ class BlackBoxGenerator:
         """
         self.model = model
         self.output_type = output_type
+        self.tools = get_formatted_tools(tools)
 
-    def __call__(self, prompt: Any, **inference_kwargs) -> Any:
+    def __call__(self, prompt: Any, **inference_kwargs) -> Output:
         """Generate a response from the model.
 
         Parameters
@@ -65,10 +74,10 @@ class BlackBoxGenerator:
 
         """
         return self.model.generate(
-            prompt, self.output_type, **inference_kwargs
+            prompt, self.output_type, tools=self.tools, **inference_kwargs
         )
 
-    def batch(self, prompts: List[Any], **inference_kwargs) -> List[Any]:
+    def batch(self, prompts: List[Any], **inference_kwargs) -> List[Output]:
         """Generate a batch of responses from the model.
 
         Parameters
@@ -85,7 +94,7 @@ class BlackBoxGenerator:
 
         """
         return self.model.generate_batch(
-            prompts, self.output_type, **inference_kwargs
+            prompts, self.output_type, tools=self.tools, **inference_kwargs
         )
 
     def stream(self, prompt: Any, **inference_kwargs) -> Iterator[Any]:
@@ -105,7 +114,7 @@ class BlackBoxGenerator:
 
         """
         return self.model.generate_stream(
-            prompt, self.output_type, **inference_kwargs
+            prompt, self.output_type, tools=self.tools, **inference_kwargs
         )
 
 
@@ -119,7 +128,13 @@ class AsyncBlackBoxGenerator:
     """
     output_type: Optional[Any]
 
-    def __init__(self, model: AsyncBlackBoxModel, output_type: Optional[Any]):
+    def __init__(
+        self,
+        model: AsyncBlackBoxModel,
+        output_type: Optional[Any],
+        *,
+        tools: Optional[ToolsInput] = None,
+    ):
         """
         Parameters
         ----------
@@ -131,8 +146,9 @@ class AsyncBlackBoxGenerator:
         """
         self.model = model
         self.output_type = output_type
+        self.tools = get_formatted_tools(tools)
 
-    async def __call__(self, prompt: Any, **inference_kwargs) -> Any:
+    async def __call__(self, prompt: Any, **inference_kwargs) -> Output:
         """Generate a response from the model.
 
         Parameters
@@ -149,10 +165,10 @@ class AsyncBlackBoxGenerator:
 
         """
         return await self.model.generate(
-            prompt, self.output_type, **inference_kwargs
+            prompt, self.output_type, tools=self.tools, **inference_kwargs
         )
 
-    async def batch(self, prompts: List[Any], **inference_kwargs) -> List[Any]:
+    async def batch(self, prompts: List[Any], **inference_kwargs) -> List[Output]:
         """Generate a batch of responses from the model.
 
         Parameters
@@ -169,7 +185,7 @@ class AsyncBlackBoxGenerator:
 
         """
         return await self.model.generate_batch(
-            prompts, self.output_type, **inference_kwargs
+            prompts, self.output_type, tools=self.tools, **inference_kwargs
         )
 
     async def stream(self, prompt: Any, **inference_kwargs) -> AsyncIterator[Any]:
@@ -189,7 +205,7 @@ class AsyncBlackBoxGenerator:
 
         """
         async for chunk in self.model.generate_stream(  # pragma: no cover
-            prompt, self.output_type, **inference_kwargs
+            prompt, self.output_type, tools=self.tools, **inference_kwargs
         ):
             yield chunk
 
@@ -218,6 +234,8 @@ class SteerableGenerator:
         model: SteerableModel,
         output_type: Optional[Any],
         backend_name: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
     ):
         """
         Parameters
@@ -231,6 +249,7 @@ class SteerableGenerator:
 
         """
         self.model = model
+        self.tools = get_formatted_tools(tools)
         if output_type is None:
             self.logits_processor = None
         else:
@@ -258,7 +277,11 @@ class SteerableGenerator:
 
     @classmethod
     def from_processor(
-        cls, model: SteerableModel, processor: LogitsProcessorType
+        cls,
+        model: SteerableModel,
+        processor: LogitsProcessorType,
+        *,
+        tools: Optional[ToolsInput] = None,
     ):
         """Create a generator from a logits processor.
 
@@ -270,13 +293,12 @@ class SteerableGenerator:
             An instance of a logits processor.
 
         """
-        instance = cls.__new__(cls)
-        instance.model = model
+        instance = cls(model, None, tools=tools)
         instance.logits_processor = processor
 
         return instance
 
-    def __call__(self, prompt: Any, **inference_kwargs) -> Any:
+    def __call__(self, prompt: Any, **inference_kwargs) -> Output:
         """Generate a response from the model.
 
         Parameters
@@ -295,10 +317,10 @@ class SteerableGenerator:
         if self.logits_processor is not None:
             self.logits_processor.reset()
         return self.model.generate(
-            prompt, self.logits_processor, **inference_kwargs
+            prompt, self.logits_processor, tools=self.tools, **inference_kwargs
         )
 
-    def batch(self, prompts: List[Any], **inference_kwargs) -> List[Any]:
+    def batch(self, prompts: List[Any], **inference_kwargs) -> List[Output]:
         """Generate a batch of responses from the model.
 
         Parameters
@@ -317,7 +339,7 @@ class SteerableGenerator:
         if self.logits_processor is not None:
             self.logits_processor.reset()
         return self.model.generate_batch(
-            prompts, self.logits_processor, **inference_kwargs
+            prompts, self.logits_processor, tools=self.tools, **inference_kwargs
         )
 
     def stream(self, prompt: Any, **inference_kwargs) -> Iterator[Any]:
@@ -339,7 +361,7 @@ class SteerableGenerator:
         if self.logits_processor is not None:
             self.logits_processor.reset()
         return self.model.generate_stream(
-            prompt, self.logits_processor, **inference_kwargs
+            prompt, self.logits_processor, tools=self.tools, **inference_kwargs
         )
 
 
@@ -348,6 +370,7 @@ def Generator(
     output_type: Optional[Any] = None,
     backend: Optional[str] = None,
     *,
+    tools: Optional[ToolsInput] = None,
     processor: Optional[LogitsProcessorType] = None,
 ) -> Union[SteerableGenerator, BlackBoxGenerator, AsyncBlackBoxGenerator]:
     """Create a generator for the given model and output parameters.
@@ -387,18 +410,18 @@ def Generator(
 
     if isinstance(model, SteerableModel): # type: ignore
         if processor is not None:
-            return SteerableGenerator.from_processor(model, processor) # type: ignore
+            return SteerableGenerator.from_processor(model, processor, tools=tools) # type: ignore
         else:
-            return SteerableGenerator(model, output_type, backend) # type: ignore
+            return SteerableGenerator(model, output_type, backend, tools=tools) # type: ignore
     else:
         if processor is not None:
             raise NotImplementedError(
                 "This model does not support logits processors"
             )
         if isinstance(model, AsyncBlackBoxModel): # type: ignore
-            return AsyncBlackBoxGenerator(model, output_type) # type: ignore
+            return AsyncBlackBoxGenerator(model, output_type, tools=tools) # type: ignore
         elif isinstance(model, BlackBoxModel): # type: ignore
-            return BlackBoxGenerator(model, output_type) # type: ignore
+            return BlackBoxGenerator(model, output_type, tools=tools) # type: ignore
         else:
             raise ValueError(
                 "The model argument must be an instance of "

--- a/outlines/models/base.py
+++ b/outlines/models/base.py
@@ -3,6 +3,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Iterator, List, Optional
 
+from outlines.tools import ToolDef, ToolsInput
+from outlines.outputs import Output
+
 
 class ModelTypeAdapter(ABC):
     """Base class for all model type adapters.
@@ -59,6 +62,13 @@ class ModelTypeAdapter(ABC):
         """
         ...
 
+    @abstractmethod
+    def format_tools(self, tools: Optional[List[ToolDef]] = None) -> List[ToolDef]:
+        """Format the tools to the expected format of the model.
+
+        """
+        ...
+
 class Model(ABC):
     """Base class for all synchronous models.
 
@@ -82,8 +92,10 @@ class Model(ABC):
         model_input: Any,
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
-    ) -> Any:
+    ) -> Output:
         """Call the model.
 
         Users can call the model directly, in which case we will create a
@@ -119,15 +131,17 @@ class Model(ABC):
         """
         from outlines.generator import Generator
 
-        return Generator(self, output_type, backend)(model_input, **inference_kwargs)
+        return Generator(self, output_type, backend, tools=tools)(model_input, **inference_kwargs)
 
     def batch(
         self,
         model_input: List[Any],
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
-    ) -> List[Any]:
+    ) -> List[Output]:
         """Make a batch call to the model (several inputs at once).
 
         Users can use the `batch` method from the model directly, in which
@@ -164,7 +178,7 @@ class Model(ABC):
         """
         from outlines import Generator
 
-        generator = Generator(self, output_type, backend)
+        generator = Generator(self, output_type, backend, tools=tools)
         return generator.batch(model_input, **inference_kwargs) # type: ignore
 
     def stream(
@@ -172,6 +186,8 @@ class Model(ABC):
         model_input: Any,
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
     ) -> Iterator[Any]:
         """Stream a response from the model.
@@ -212,7 +228,7 @@ class Model(ABC):
         """
         from outlines import Generator
 
-        generator = Generator(self, output_type, backend)
+        generator = Generator(self, output_type, backend, tools=tools)
         return generator.stream(model_input, **inference_kwargs) # type: ignore
 
     @abstractmethod
@@ -220,8 +236,9 @@ class Model(ABC):
         self,
         model_input: Any,
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
-    ) -> Any:
+    ) -> Output:
         """Generate a response from the model.
 
         The output_type argument contains a logits processor for steerable
@@ -250,8 +267,9 @@ class Model(ABC):
         self,
         model_input: List[Any],
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
-    ) -> List[Any]:
+    ) -> List[Output]:
         """Generate a batch of responses from the model.
 
         The output_type argument contains a logits processor for steerable
@@ -279,8 +297,9 @@ class Model(ABC):
         self,
         model_input: Any,
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
-    ) -> Iterator[Any]:
+    ) -> Iterator[Output]:
         """Generate a stream of responses from the model.
 
         The output_type argument contains a logits processor for steerable
@@ -327,8 +346,10 @@ class AsyncModel(ABC):
         model_input: Any,
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
-    ) -> Any:
+    ) -> Output:
         """Call the model.
 
         Users can call the model directly, in which case we will create a
@@ -364,7 +385,7 @@ class AsyncModel(ABC):
         """
         from outlines import Generator
 
-        generator = Generator(self, output_type, backend)
+        generator = Generator(self, output_type, backend, tools=tools)
         return await generator(model_input, **inference_kwargs)
 
     async def batch(
@@ -372,8 +393,10 @@ class AsyncModel(ABC):
         model_input: List[Any],
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
-    ) -> List[Any]:
+    ) -> List[Output]:
         """Make a batch call to the model (several inputs at once).
 
         Users can use the `batch` method from the model directly, in which
@@ -410,7 +433,7 @@ class AsyncModel(ABC):
         """
         from outlines import Generator
 
-        generator = Generator(self, output_type, backend)
+        generator = Generator(self, output_type, backend, tools=tools)
         return await generator.batch(model_input, **inference_kwargs) # type: ignore
 
     async def stream(
@@ -418,6 +441,8 @@ class AsyncModel(ABC):
         model_input: Any,
         output_type: Optional[Any] = None,
         backend: Optional[str] = None,
+        *,
+        tools: Optional[ToolsInput] = None,
         **inference_kwargs: Any
     ) -> AsyncIterator[Any]:
         """Stream a response from the model.
@@ -458,7 +483,7 @@ class AsyncModel(ABC):
         """
         from outlines import Generator
 
-        generator = Generator(self, output_type, backend)
+        generator = Generator(self, output_type, backend, tools=tools)
 
         async for chunk in generator.stream(model_input, **inference_kwargs):  # type: ignore
             yield chunk
@@ -468,8 +493,9 @@ class AsyncModel(ABC):
         self,
         model_input: Any,
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
-    ) -> Any:
+    ) -> Output:
         """Generate a response from the model.
 
         The output_type argument contains a logits processor for steerable
@@ -498,8 +524,9 @@ class AsyncModel(ABC):
         self,
         model_input: List[Any],
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
-    ) -> List[Any]:
+    ) -> List[Output]:
         """Generate a batch of responses from the model.
 
         The output_type argument contains a logits processor for steerable
@@ -528,6 +555,7 @@ class AsyncModel(ABC):
         self,
         model_input: Any,
         output_type: Optional[Any] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any
     ) -> AsyncIterator[Any]:
         """Generate a stream of responses from the model.

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     AsyncIterator,
     Iterator,
+    List,
     Optional,
     Union,
 )
@@ -16,6 +17,8 @@ from pydantic import BaseModel, TypeAdapter
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
 from outlines.models.utils import set_additional_properties_false_json_schema
+from outlines.outputs import Output
+from outlines.tools import ToolDef, ToolCall
 from outlines.types import JsonSchema, Regex, CFG
 from outlines.types.utils import (
     is_dataclass,
@@ -224,6 +227,29 @@ class OpenAITypeAdapter(ModelTypeAdapter):
         """
         return {"response_format": {"type": "json_object"}}
 
+    def format_tools(self, tools: Optional[List[ToolDef]] = None) -> list:
+        """Format the tools for the OpenAI client.
+
+        """
+        if not tools:
+            return []
+
+        formatted_tools = []
+        for tool in tools:
+            formatted_tools.append({
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "parameters": {
+                        "type": "object",
+                        "properties": {key: {"type": value} for key, value in tool["parameters"].items()},
+                        "required": tool["required"],
+                    },
+                },
+            })
+        return formatted_tools
+
 
 class OpenAI(Model):
     """Thin wrapper around the `openai.OpenAI` client.
@@ -255,6 +281,7 @@ class OpenAI(Model):
         self,
         model_input: Union[Chat, list, str],
         output_type: Optional[Union[type[BaseModel], str]] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any,
     ) -> Union[str, list[str]]:
         """Generate text using OpenAI.
@@ -280,9 +307,12 @@ class OpenAI(Model):
 
         messages = self.type_adapter.format_input(model_input)
         response_format = self.type_adapter.format_output_type(output_type)
+        tools = self.type_adapter.format_tools(tools)
 
         if "model" not in inference_kwargs and self.model_name is not None:
             inference_kwargs["model"] = self.model_name
+        if tools:
+            inference_kwargs["tools"] = tools
 
         try:
             result = self.client.chat.completions.create(
@@ -300,21 +330,39 @@ class OpenAI(Model):
                 raise e
 
         messages = [choice.message for choice in result.choices]
+
+        outputs = []
         for message in messages:
             if message.refusal is not None:
                 raise ValueError(
                     f"OpenAI refused to answer the request: {message.refusal}"
                 )
+            if message.tool_calls:
+                outputs.append(Output(
+                    content=message.content,
+                    type="tool_call",
+                    tool_calls=[
+                        ToolCall(
+                            name=tool.function.name,
+                            args=tool.function.arguments,
+                            tool_call_id=tool.id
+                        )
+                        for tool in message.tool_calls
+                    ],
+                ))
+            else:
+                outputs.append(Output(content=message.content, type="assistant"))
 
-        if len(messages) == 1:
-            return messages[0].content
+        if len(outputs) == 1:
+            return outputs[0]
         else:
-            return [message.content for message in messages]
+            return outputs
 
     def generate_batch(
         self,
         model_input,
         output_type = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs,
     ):
         raise NotImplementedError(
@@ -325,6 +373,7 @@ class OpenAI(Model):
         self,
         model_input: Union[Chat, list, str],
         output_type: Optional[Union[type[BaseModel], str]] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs,
     ) -> Iterator[str]:
         """Stream text using OpenAI.
@@ -405,6 +454,7 @@ class AsyncOpenAI(AsyncModel):
         self,
         model_input: Union[Chat, list, str],
         output_type: Optional[Union[type[BaseModel], str]] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs: Any,
     ) -> Union[str, list[str]]:
         """Generate text using OpenAI.
@@ -465,6 +515,7 @@ class AsyncOpenAI(AsyncModel):
         self,
         model_input,
         output_type = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs,
     ):
         raise NotImplementedError(
@@ -475,6 +526,7 @@ class AsyncOpenAI(AsyncModel):
         self,
         model_input: Union[Chat, list, str],
         output_type: Optional[Union[type[BaseModel], str]] = None,
+        tools: Optional[List[ToolDef]] = None,
         **inference_kwargs,
     ) -> AsyncIterator[str]:
         """Stream text using OpenAI.

--- a/outlines/outputs.py
+++ b/outlines/outputs.py
@@ -1,0 +1,16 @@
+import sys
+from typing import Literal, Optional
+
+from outlines.tools import ToolCall
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+class Output(TypedDict):
+    content: str
+    type: Literal["system", "tool_call", "user", "assistant"]
+    tool_calls: Optional[list[ToolCall]]
+    reasoning: Optional[str]

--- a/outlines/tools.py
+++ b/outlines/tools.py
@@ -1,0 +1,34 @@
+import sys
+from typing import Any, List, Optional, Union, Callable
+
+from pydantic import BaseModel
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+class MCPServer(BaseModel):
+    url: str
+
+
+class ToolDef(TypedDict):
+    name: str
+    description: str
+    parameters: dict
+    required: list[str]
+
+
+class ToolCall(TypedDict):
+    name: str
+    tool_call_id: Optional[str]
+    args: dict[str, Any]
+
+
+ToolsInput = Union[MCPServer, List[ToolDef | Callable]]
+
+
+def get_formatted_tools(tools: Optional[ToolsInput] = None) -> List[ToolDef]:
+    # TODO: Implement this
+    return tools

--- a/test_tools.py
+++ b/test_tools.py
@@ -1,0 +1,26 @@
+from outlines.models import from_openai
+from openai import OpenAI
+
+client = OpenAI()
+
+model = from_openai(
+    OpenAI(),
+    "gpt-4o-mini",
+)
+
+tool = {
+    "name": "get_current_time",
+    "description": "Get the current time",
+    "parameters": {
+        "city": "string",
+    },
+    "required": ["city"],
+}
+
+result = model(
+    "What is the current time in Tokyo?",
+    tools=[tool],
+)
+
+print(result)
+# {'content': None, 'type': 'tool_call', 'tool_calls': [{'name': 'get_current_time', 'args': '{"city":"Tokyo"}', 'tool_call_id': 'call_B0gcCjHtA54GxcZuOAggAu6v'}]}


### PR DESCRIPTION
The idea is that for the tools definition, the user could provide either of those:
- list of callables
- list of dicts containing tool definitions
- an MCPServer instance

The `tools` argument would be provided in the same places as the `output_type`. In the generator, there is a step to turn the user tools input into a list of dicts (a bit similar to how we are compiling the output_type for steerable models).

Then, each model's type adapter would have a `format_tools` method that would turn this standardized tool dict definition into the argument expected by the model.

Each model, upon receiving a response for the text generation, would then return an `Output` object (distinguishing between regular responses and tool calls).

This `Output` instance returned by the model could then be used as a message in a `Chat` input.

Something yet to be figured out is how we handle streaming.