### PR TITLE
feat(mlxlm): support vision models via mlx-vlm processors

### DIFF
--- a/docs/features/models/mlxlm.md
+++ b/docs/features/models/mlxlm.md
@@ -10,14 +10,14 @@ Outlines provides an integration with [mlx-lm](https://github.com/ml-explore/mlx
 
     You need a device that [supports Metal](https://support.apple.com/en-us/102894) to use the mlx-lm integration.
 
-    You need to install the `mlx` and `mlx-lm` libraries to be able to use mlx in Outlines. Install all optional dependencies of the `MLXLM` model with: `pip install "outlines[mlxlm]"`.
+    You need to install the `mlx` and `mlx-lm` libraries to be able to use mlx in Outlines. Vision models additionally require `mlx-vlm`. Install all optional dependencies of the `MLXLM` model with: `pip install "outlines[mlxlm]"`.
 
 ## Model Initialization
 
 To create a MLXLM model instance, you can use the `from_mlxlm` function. It takes 2 arguments:
 
 - `model`: an `mlx.nn.Module` instance
-- `tokenizer`: a `transformers.PreTrainedTokenizer` instance
+- `tokenizer`: a `transformers.PreTrainedTokenizer` instance, or a `transformers` processor for vision models (see [Vision Models](#vision-models))
 
 However, we recommend you simply pass on the output of the `mlx_lm.load` function (it takes a model name as an argument).
 
@@ -115,6 +115,48 @@ model = outlines.from_mlxlm(
 result = model.batch(["What's the capital of Lithuania?", "What's the capital of Latvia?"], max_tokens=20)
 print(result) # ['Vilnius', 'Riga']
 ```
+
+## Vision Models
+
+Outlines also supports vision models running through [mlx-vlm](https://github.com/Blaizzy/mlx-vlm). You need to install the `mlx-vlm` library to use it: `pip install mlx-vlm` (already included in `outlines[mlxlm]`).
+
+`from_mlxlm` detects whether the second argument is a tokenizer or a `transformers` processor and returns an `MLXLM` or an `MLXLMMultiModal` model instance accordingly, similarly to `from_transformers`. `MLXLMMultiModal` inherits from `MLXLM` and generates through `mlx-vlm` instead of `mlx-lm`.
+
+To load a vision model, pass on the output of `mlx_vlm.load` instead of `mlx_lm.load`:
+
+```python
+import outlines
+import mlx_vlm
+
+# Create the model
+model = outlines.from_mlxlm(
+    *mlx_vlm.load("mlx-community/SmolVLM-256M-Instruct-4bit")
+)
+```
+
+Images must be provided through a `Chat` input containing `outlines.inputs.Image` instances. There is no need to add image placeholder tags to the prompt, the model's chat template takes care of that.
+
+```python
+import outlines
+import mlx_vlm
+from outlines.inputs import Chat, Image
+from PIL import Image as PILImage
+
+model = outlines.from_mlxlm(
+    *mlx_vlm.load("mlx-community/SmolVLM-256M-Instruct-4bit")
+)
+
+image = PILImage.open("cat.png")
+
+prompt = Chat([
+    {"role": "user", "content": ["Describe this image in one sentence.", Image(image)]},
+])
+
+result = model(prompt, max_tokens=50)
+print(result) # 'A black cat is sitting on a couch.'
+```
+
+Constrained generation, streaming and plain string inputs (with no image) all work the same way as with text-only mlx-lm models. Batch generation isn't supported for vision models.
 
 ## Structured Generation
 

--- a/docs/features/models/mlxlm.md
+++ b/docs/features/models/mlxlm.md
@@ -10,14 +10,14 @@ Outlines provides an integration with [mlx-lm](https://github.com/ml-explore/mlx
 
     You need a device that [supports Metal](https://support.apple.com/en-us/102894) to use the mlx-lm integration.
 
-    You need to install the `mlx` and `mlx-lm` libraries to be able to use mlx in Outlines. Install all optional dependencies of the `MLXLM` model with: `pip install "outlines[mlxlm]"`.
+    You need to install the `mlx` and `mlx-lm` libraries to be able to use mlx in Outlines. Vision models additionally require `mlx-vlm`. Install all optional dependencies of the `MLXLM` model with: `pip install "outlines[mlxlm]"`.
 
 ## Model Initialization
 
 To create a MLXLM model instance, you can use the `from_mlxlm` function. It takes 2 arguments:
 
 - `model`: an `mlx.nn.Module` instance
-- `tokenizer`: a `transformers.PreTrainedTokenizer` instance
+- `tokenizer`: a `transformers.PreTrainedTokenizer` instance, or a `transformers` processor for vision models (see [Vision Models](#vision-models))
 
 However, we recommend you simply pass on the output of the `mlx_lm.load` function (it takes a model name as an argument).
 
@@ -115,6 +115,48 @@ model = outlines.from_mlxlm(
 result = model.batch(["What's the capital of Lithuania?", "What's the capital of Latvia?"], max_tokens=20)
 print(result) # ['Vilnius', 'Riga']
 ```
+
+## Vision Models
+
+Outlines also supports vision models running through [mlx-vlm](https://github.com/Blaizzy/mlx-vlm). You need to install the `mlx-vlm` library to use it: `pip install mlx-vlm` (already included in `outlines[mlxlm]`).
+
+`from_mlxlm` detects whether the second argument is a tokenizer or a `transformers` processor and returns an `MLXLM` or an `MLXLMMultiModal` model instance accordingly, similarly to `from_transformers`. `MLXLMMultiModal` inherits from `MLXLM` and generates through `mlx-vlm` instead of `mlx-lm`.
+
+To load a vision model, pass on the output of `mlx_vlm.load` instead of `mlx_lm.load`:
+
+```python
+import outlines
+import mlx_vlm
+
+# Create the model
+model = outlines.from_mlxlm(
+    *mlx_vlm.load("mlx-community/SmolVLM-256M-Instruct-4bit")
+)
+```
+
+Images must be provided through a `Chat` input containing `outlines.inputs.Image` instances. There is no need to add image placeholder tags to the prompt, the model's chat template takes care of that. For models with chat templates, images must be attached to the first user message, which must be in the first or second position. When that message is first, the next message cannot also be from the user. Prompt-only models such as PaliGemma, Molmo, and Florence-2 accept a single user message. Inputs outside these shapes raise `ValueError` instead of silently dropping, moving, or duplicating image tokens.
+
+```python
+import outlines
+import mlx_vlm
+from outlines.inputs import Chat, Image
+from PIL import Image as PILImage
+
+model = outlines.from_mlxlm(
+    *mlx_vlm.load("mlx-community/SmolVLM-256M-Instruct-4bit")
+)
+
+image = PILImage.open("cat.png")
+
+prompt = Chat([
+    {"role": "user", "content": ["Describe this image in one sentence.", Image(image)]},
+])
+
+result = model(prompt, max_tokens=50)
+print(result) # 'A black cat is sitting on a couch.'
+```
+
+Streaming and plain string inputs (with no image) work the same way as with text-only mlx-lm models. Structured and batch generation aren't supported for vision models.
 
 ## Structured Generation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ anthropic = ["anthropic"]
 dottxt = ["dottxt"]
 gemini = ["google-genai"]
 llamacpp = ["huggingface-hub", "llama-cpp-python", "numba"]
-mlxlm = ["datasets", "mlx", "mlx-lm"]
+mlxlm = ["datasets", "mlx", "mlx-lm", "mlx-vlm"]
 lmstudio = ["lmstudio"]
 ollama = ["ollama"]
 openai = ["openai"]
@@ -68,6 +68,7 @@ test = [
     "responses",
     "llama-cpp-python",
     "mlx-lm>=0.19.2; platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "mlx-vlm; platform_machine == 'arm64' and sys_platform == 'darwin'",
     "huggingface_hub",
     "openai>=1.0.0",
     "datasets",
@@ -149,6 +150,7 @@ module = [
     "mistralai.*",
     "mamba_ssm.*",
     "mlx_lm.*",
+    "mlx_vlm.*",
     "mlx.*",
     "numpy.*",
     "cloudpickle.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ anthropic = ["anthropic"]
 dottxt = ["dottxt"]
 gemini = ["google-genai"]
 llamacpp = ["huggingface-hub", "llama-cpp-python", "numba"]
-mlxlm = ["datasets", "mlx", "mlx-lm"]
+mlxlm = ["datasets", "mlx", "mlx-lm", "mlx-vlm"]
 lmstudio = ["lmstudio"]
 ollama = ["ollama"]
 openai = ["openai"]
@@ -67,6 +67,7 @@ test = [
     "responses",
     "llama-cpp-python",
     "mlx-lm>=0.19.2; platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "mlx-vlm; platform_machine == 'arm64' and sys_platform == 'darwin'",
     "huggingface_hub",
     "openai>=1.0.0",
     "datasets",
@@ -148,6 +149,7 @@ module = [
     "mistralai.*",
     "mamba_ssm.*",
     "mlx_lm.*",
+    "mlx_vlm.*",
     "mlx.*",
     "numpy.*",
     "cloudpickle.*",
@@ -165,6 +167,7 @@ module = [
     "datasets.*",
     "openai.*",
     "requests.*",
+    "urllib3.*",
     "responses.*",
     "vllm.*",
     "iso3166.*",

--- a/src/outlines/backends/llguidance.py
+++ b/src/outlines/backends/llguidance.py
@@ -223,9 +223,7 @@ class LLGuidanceBackend(BaseBackend):
         elif isinstance(model, MLXLM): # pragma: no cover
             import llguidance.hf
 
-            return llguidance.hf.from_tokenizer(
-                model.mlx_tokenizer._tokenizer
-            )
+            return llguidance.hf.from_tokenizer(model.hf_tokenizer)
 
         else: # pragma: no cover
             raise ValueError(

--- a/src/outlines/backends/outlines_core.py
+++ b/src/outlines/backends/outlines_core.py
@@ -197,7 +197,7 @@ class OutlinesCoreBackend(BaseBackend):
             eos_token = tokenizer.eos_token
             token_to_str = tokenizer.convert_token_to_string
         elif isinstance(model, MLXLM):  # pragma: no cover
-            tokenizer = model.mlx_tokenizer  # type: ignore
+            tokenizer = model.hf_tokenizer  # type: ignore
             vocabulary = tokenizer.get_vocab()
             eos_token_id = tokenizer.eos_token_id
             eos_token = tokenizer.eos_token

--- a/src/outlines/backends/xgrammar.py
+++ b/src/outlines/backends/xgrammar.py
@@ -129,7 +129,7 @@ class XGrammarBackend(BaseBackend):
         if isinstance(model, Transformers):
             tokenizer = model.hf_tokenizer
         elif isinstance(model, MLXLM): # pragma: no cover
-            tokenizer = model.mlx_tokenizer._tokenizer
+            tokenizer = model.hf_tokenizer
         else: # pragma: no cover
             raise ValueError(
                 "The xgrammar backend only supports Transformers and "

--- a/src/outlines/backends/xgrammar.py
+++ b/src/outlines/backends/xgrammar.py
@@ -126,7 +126,7 @@ class XGrammarBackend(BaseBackend):
         if isinstance(model, Transformers):
             tokenizer = model.hf_tokenizer
         elif isinstance(model, MLXLM): # pragma: no cover
-            tokenizer = model.mlx_tokenizer._tokenizer
+            tokenizer = model.hf_tokenizer
         else: # pragma: no cover
             raise ValueError(
                 "The xgrammar backend only supports Transformers and "

--- a/src/outlines/models/__init__.py
+++ b/src/outlines/models/__init__.py
@@ -15,7 +15,7 @@ from .gemini import Gemini, from_gemini
 from .llamacpp import LlamaCpp, from_llamacpp
 from .lmstudio import AsyncLMStudio, LMStudio, from_lmstudio
 from .mistral import AsyncMistral, Mistral, from_mistral
-from .mlxlm import MLXLM, from_mlxlm
+from .mlxlm import MLXLM, MLXLMMultiModal, from_mlxlm
 from .ollama import AsyncOllama, Ollama, from_ollama
 from .openai import AsyncOpenAI, OpenAI, from_openai
 from .sglang import AsyncSGLang, SGLang, from_sglang
@@ -74,6 +74,7 @@ __all__ = [
     "Mistral",
     "from_mistral",
     "MLXLM",
+    "MLXLMMultiModal",
     "from_mlxlm",
     "AsyncOllama",
     "Ollama",

--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -1,31 +1,30 @@
-"""Integration with the `mlx_lm` library.
+"""Integration with the `mlx_lm` and `mlx_vlm` libraries.
 
 Local runtime calls intentionally bypass
 outlines.exceptions.normalize_provider_errors().
 """
 
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 try:
     from transformers import PreTrainedTokenizerBase
 except ImportError:  # pragma: no cover
     PreTrainedTokenizerBase = None  # type: ignore
 
-from outlines.inputs import Chat
+from outlines.inputs import Chat, Image
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import _check_hf_chat_template
 from outlines.models.transformers import TransformerTokenizer
 from outlines.processors import OutlinesLogitsProcessor
 
 if TYPE_CHECKING:
-    from typing import Union
     import mlx.nn as nn
     from mlx_lm.tokenizer_utils import TokenizerWrapper
-    from transformers import PreTrainedTokenizer
+    from transformers import PreTrainedTokenizer, ProcessorMixin
     MLXTokenizer = Union["TokenizerWrapper", "PreTrainedTokenizer"]
 
-__all__ = ["MLXLM", "from_mlxlm"]
+__all__ = ["MLXLM", "MLXLMMultiModal", "from_mlxlm"]
 
 
 class MLXLMTypeAdapter(ModelTypeAdapter):
@@ -133,6 +132,8 @@ class MLXLM(Model):
         inner = getattr(tokenizer, "_tokenizer", tokenizer)
         hf_tokenizer = inner if isinstance(inner, PreTrainedTokenizerBase) else tokenizer
         self.tokenizer = TransformerTokenizer(hf_tokenizer)
+        # self.hf_tokenizer is used by the structured generation backends
+        self.hf_tokenizer = hf_tokenizer
         self.type_adapter = MLXLMTypeAdapter(
             tokenizer=tokenizer,
             has_chat_template=_check_hf_chat_template(tokenizer)
@@ -267,22 +268,247 @@ class MLXLM(Model):
             yield gen_response.text
 
 
-def from_mlxlm(model: "nn.Module", tokenizer: "MLXTokenizer") -> MLXLM:
-    """Create an Outlines `MLXLM` model instance from an `mlx_lm` model and a
-    tokenizer.
+class MLXLMMultiModalTypeAdapter(ModelTypeAdapter):
+    """Type adapter for the `MLXLMMultiModal` model."""
+
+    def __init__(self, tokenizer: "PreTrainedTokenizer"):
+        self.tokenizer = tokenizer
+
+    @singledispatchmethod
+    def format_input(self, model_input):
+        """Generate the prompt and images arguments to pass to the model.
+
+        Parameters
+        ----------
+        model_input
+            The input provided by the user.
+
+        Returns
+        -------
+        dict
+            The formatted input to be passed to the model, containing a
+            `prompt` key and an `images` key.
+
+        """
+        raise NotImplementedError(
+            f"The input type {type(model_input)} is not available with "
+            "mlx-vlm. The available types are `str` and `Chat`."
+        )
+
+    @format_input.register(str)
+    def format_str_input(self, model_input: str) -> dict:
+        # the chat template is needed to position the prompt correctly
+        # relative to the image tokens
+        return self.format_chat_input(
+            Chat([{"role": "user", "content": model_input}])
+        )
+
+    @format_input.register(Chat)
+    def format_chat_input(self, model_input: Chat) -> dict:
+        conversation = []
+        images: List[Any] = []
+
+        for message in model_input.messages:
+            content = message["content"]
+
+            if isinstance(content, str):
+                conversation.append({"role": message["role"], "content": content})
+                continue
+
+            if not isinstance(content, list):
+                raise ValueError(
+                    "The content of a message must be a string or a list "
+                    "containing a text prompt and `Image` instances."
+                )
+
+            text_parts = [item for item in content if isinstance(item, str)]
+            assets = [item for item in content if not isinstance(item, str)]
+            if any(not isinstance(asset, Image) for asset in assets):
+                raise ValueError(
+                    "mlx-vlm only supports `Image` assets in the message "
+                    "content. Audio and video inputs are not available "
+                    "with this integration."
+                )
+
+            images.extend(asset.image for asset in assets)
+            conversation.append({
+                "role": message["role"],
+                "content": (
+                    [{"type": "image"} for _ in assets]
+                    + [{"type": "text", "text": " ".join(text_parts)}]
+                ),
+            })
+
+        prompt = self.tokenizer.apply_chat_template(
+            conversation,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        return {"prompt": prompt, "images": images}
+
+    def format_output_type(
+        self, output_type: Optional[OutlinesLogitsProcessor] = None,
+    ) -> Optional[List[OutlinesLogitsProcessor]]:
+        """Generate the logits processor argument to pass to the model.
+
+        Parameters
+        ----------
+        output_type
+            The logits processor provided.
+
+        Returns
+        -------
+        Optional[list[OutlinesLogitsProcessor]]
+            The logits processor argument to be passed to the model.
+
+        """
+        if not output_type:
+            return None
+        return [output_type]
+
+
+class MLXLMMultiModal(MLXLM):
+    """Thin wrapper around an `mlx_vlm` model.
+
+    We rely on the `__init__` method of the `MLXLM` class to handle most of
+    the initialization and then add elements specific to vision models.
+
+    """
+
+    def __init__(
+        self,
+        model: "nn.Module",
+        processor: "ProcessorMixin",
+    ):
+        """
+        Parameters
+        ----------
+        model
+            An instance of an `mlx_vlm` model.
+        processor
+            An instance of a `transformers` processor (returned along with
+            the model by `mlx_vlm.load`).
+
+        """
+        # self.processor is used by the mlx-vlm generate functions
+        self.processor = processor
+        super().__init__(model, processor.tokenizer)
+        self.type_adapter = MLXLMMultiModalTypeAdapter(
+            tokenizer=processor.tokenizer
+        )
+
+    def generate(
+        self,
+        model_input: Union[str, Chat],
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ) -> str:
+        """Generate text using `mlx-vlm`.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The logits processor the model will use to constrain the format of
+            the generated text.
+        kwargs
+            Additional keyword arguments to pass to the `mlx-vlm` library.
+
+        Returns
+        -------
+        str
+            The text generated by the model.
+
+        """
+        from mlx_vlm import generate
+
+        formatted_input = self.type_adapter.format_input(model_input)
+
+        return generate(
+            self.model,
+            self.processor,
+            formatted_input["prompt"],
+            image=formatted_input["images"],
+            logits_processors=self.type_adapter.format_output_type(output_type),
+            **kwargs,
+        ).text
+
+    def generate_batch(
+        self,
+        model_input,
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ):
+        """Not available for `mlx-vlm` models."""
+        raise NotImplementedError(
+            "mlx-vlm does not support batch generation through this "
+            "integration. Call the model once per input instead."
+        )
+
+    def generate_stream(
+        self,
+        model_input: Union[str, Chat],
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ) -> Iterator[str]:
+        """Stream text using `mlx-vlm`.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            The logits processor the model will use to constrain the format of
+            the generated text.
+        kwargs
+            Additional keyword arguments to pass to the `mlx-vlm` library.
+
+        Returns
+        -------
+        Iterator[str]
+            An iterator that yields the text generated by the model.
+
+        """
+        from mlx_vlm import stream_generate
+
+        formatted_input = self.type_adapter.format_input(model_input)
+
+        for gen_response in stream_generate(
+            self.model,
+            self.processor,
+            formatted_input["prompt"],
+            image=formatted_input["images"],
+            logits_processors=self.type_adapter.format_output_type(output_type),
+            **kwargs,
+        ):
+            yield gen_response.text
+
+
+def from_mlxlm(
+    model: "nn.Module",
+    tokenizer: "Union[MLXTokenizer, ProcessorMixin]",
+) -> Union[MLXLM, MLXLMMultiModal]:
+    """Create an Outlines `MLXLM` or `MLXLMMultiModal` model instance from an
+    `mlx_lm` or `mlx_vlm` model and a tokenizer or processor.
 
     Parameters
     ----------
     model
-        An instance of an `mlx_lm` model.
+        An instance of an `mlx_lm` or `mlx_vlm` model.
     tokenizer
-        An instance of an `mlx_lm` tokenizer or of a compatible
-        transformers tokenizer.
+        An instance of an `mlx_lm` tokenizer, of a compatible transformers
+        tokenizer, or of a `transformers` processor (returned along with the
+        model by `mlx_vlm.load` for vision models).
 
     Returns
     -------
-    MLXLM
-        An Outlines `MLXLM` model instance.
+    Union[MLXLM, MLXLMMultiModal]
+        An Outlines `MLXLM` or `MLXLMMultiModal` model instance.
 
     """
+    from transformers import ProcessorMixin
+
+    if isinstance(tokenizer, ProcessorMixin):
+        return MLXLMMultiModal(model, tokenizer)
     return MLXLM(model, tokenizer)

--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -1,31 +1,36 @@
-"""Integration with the `mlx_lm` library.
+"""Integration with the `mlx_lm` and `mlx_vlm` libraries.
 
 Local runtime calls intentionally bypass
 outlines.exceptions.normalize_provider_errors().
 """
 
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Union
 
 try:
     from transformers import PreTrainedTokenizerBase
 except ImportError:  # pragma: no cover
     PreTrainedTokenizerBase = None  # type: ignore
 
-from outlines.inputs import Chat
+from outlines.inputs import Chat, Image
 from outlines.models.base import Model, ModelTypeAdapter
 from outlines.models.tokenizer import _check_hf_chat_template
 from outlines.models.transformers import TransformerTokenizer
 from outlines.processors import OutlinesLogitsProcessor
 
 if TYPE_CHECKING:
-    from typing import Union
     import mlx.nn as nn
     from mlx_lm.tokenizer_utils import TokenizerWrapper
-    from transformers import PreTrainedTokenizer
+    from transformers import PreTrainedTokenizer, ProcessorMixin
     MLXTokenizer = Union["TokenizerWrapper", "PreTrainedTokenizer"]
 
-__all__ = ["MLXLM", "from_mlxlm"]
+__all__ = ["MLXLM", "MLXLMMultiModal", "from_mlxlm"]
+
+_MLX_VLM_PROMPT_ONLY_MODEL_TYPES = frozenset({
+    "florence2",
+    "molmo",
+    "paligemma",
+})
 
 
 class MLXLMTypeAdapter(ModelTypeAdapter):
@@ -133,6 +138,7 @@ class MLXLM(Model):
         inner = getattr(tokenizer, "_tokenizer", tokenizer)
         hf_tokenizer = inner if isinstance(inner, PreTrainedTokenizerBase) else tokenizer
         self.tokenizer = TransformerTokenizer(hf_tokenizer)
+        self.hf_tokenizer = hf_tokenizer
         self.type_adapter = MLXLMTypeAdapter(
             tokenizer=tokenizer,
             has_chat_template=_check_hf_chat_template(tokenizer)
@@ -267,22 +273,279 @@ class MLXLM(Model):
             yield gen_response.text
 
 
-def from_mlxlm(model: "nn.Module", tokenizer: "MLXTokenizer") -> MLXLM:
-    """Create an Outlines `MLXLM` model instance from an `mlx_lm` model and a
-    tokenizer.
+class MLXLMMultiModalTypeAdapter(ModelTypeAdapter):
+    """Type adapter for the `MLXLMMultiModal` model."""
+
+    def __init__(self, processor: "ProcessorMixin", config: Any):
+        self.processor = processor
+        self.config = config
+        self.model_type = (
+            config["model_type"]
+            if isinstance(config, dict)
+            else config.model_type
+        )
+
+    @singledispatchmethod
+    def format_input(self, model_input):
+        """Generate the prompt and images arguments to pass to the model.
+
+        Parameters
+        ----------
+        model_input
+            The input provided by the user.
+
+        Returns
+        -------
+        dict
+            The formatted input to be passed to the model, containing a
+            `prompt` key and an `images` key.
+
+        """
+        raise NotImplementedError(
+            f"The input type {type(model_input)} is not available with "
+            "mlx-vlm. The available types are `str` and `Chat`."
+        )
+
+    @format_input.register(str)
+    def format_str_input(self, model_input: str) -> dict:
+        # the chat template is needed to position the prompt correctly
+        # relative to the image tokens
+        return self.format_chat_input(
+            Chat([{"role": "user", "content": model_input}])
+        )
+
+    @format_input.register(Chat)
+    def format_chat_input(self, model_input: Chat) -> dict:
+        if self.model_type in _MLX_VLM_PROMPT_ONLY_MODEL_TYPES and (
+            len(model_input.messages) != 1
+            or model_input.messages[0]["role"] != "user"
+        ):
+            raise ValueError(
+                "This mlx-vlm model only supports a single user message."
+            )
+
+        messages = []
+        images: List[Any] = []
+        first_user_index = next(
+            (
+                index
+                for index, message in enumerate(model_input.messages)
+                if message["role"] == "user"
+            ),
+            None,
+        )
+
+        for index, message in enumerate(model_input.messages):
+            content = message["content"]
+
+            if isinstance(content, str):
+                messages.append({"role": message["role"], "content": content})
+                continue
+
+            if not isinstance(content, list):
+                raise ValueError(
+                    "The content of a message must be a string or a list "
+                    "containing a text prompt and `Image` instances."
+                )
+
+            text_parts = [item for item in content if isinstance(item, str)]
+            assets = [item for item in content if not isinstance(item, str)]
+            if any(not isinstance(asset, Image) for asset in assets):
+                raise ValueError(
+                    "mlx-vlm only supports `Image` assets in the message "
+                    "content. Audio and video inputs are not available "
+                    "with this integration."
+                )
+            if assets and index != first_user_index:
+                raise ValueError(
+                    "mlx-vlm only supports images in the first user message."
+                )
+            if assets and first_user_index not in (0, 1):
+                raise ValueError(
+                    "mlx-vlm only supports images when the first user message "
+                    "is the first or second message."
+                )
+            if (
+                assets
+                and index == 0
+                and len(model_input.messages) > 1
+                and model_input.messages[1]["role"] == "user"
+            ):
+                raise ValueError(
+                    "mlx-vlm does not support images when the first two "
+                    "messages are user messages."
+                )
+
+            images.extend(asset.image for asset in assets)
+            messages.append({
+                "role": message["role"],
+                "content": " ".join(text_parts),
+            })
+
+        from mlx_vlm import apply_chat_template
+
+        prompt = apply_chat_template(
+            self.processor,
+            self.config,
+            messages,
+            num_images=len(images),
+        )
+        return {"prompt": prompt, "images": images}
+
+    def format_output_type(
+        self, output_type: Optional[OutlinesLogitsProcessor] = None,
+    ) -> None:
+        """Reject output types because `mlx-vlm` cannot apply logits processors."""
+        if output_type is not None:
+            raise NotImplementedError(
+                "mlx-vlm does not support structured generation."
+            )
+
+
+class MLXLMMultiModal(MLXLM):
+    """Thin wrapper around an `mlx_vlm` model.
+
+    We rely on the `__init__` method of the `MLXLM` class to handle most of
+    the initialization and then add elements specific to vision models.
+
+    """
+
+    def __init__(
+        self,
+        model: "nn.Module",
+        processor: "ProcessorMixin",
+    ):
+        """
+        Parameters
+        ----------
+        model
+            An instance of an `mlx_vlm` model.
+        processor
+            An instance of a `transformers` processor (returned along with
+            the model by `mlx_vlm.load`).
+
+        """
+        self.processor = processor
+        super().__init__(model, processor.tokenizer)
+        self.type_adapter = MLXLMMultiModalTypeAdapter(
+            processor=processor,
+            config=model.config,
+        )
+
+    def generate(
+        self,
+        model_input: Union[str, Chat],
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ) -> str:
+        """Generate text using `mlx-vlm`.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            Must be `None`. Structured generation is not available with
+            `mlx-vlm`.
+        kwargs
+            Additional keyword arguments to pass to the `mlx-vlm` library.
+
+        Returns
+        -------
+        str
+            The text generated by the model.
+
+        """
+        self.type_adapter.format_output_type(output_type)
+
+        from mlx_vlm import generate
+
+        formatted_input = self.type_adapter.format_input(model_input)
+
+        return generate(
+            self.model,
+            self.processor,
+            formatted_input["prompt"],
+            image=formatted_input["images"],
+            **kwargs,
+        ).text
+
+    def generate_batch(
+        self,
+        model_input,
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ):
+        """Not available for `mlx-vlm` models."""
+        raise NotImplementedError(
+            "mlx-vlm does not support batch generation through this "
+            "integration. Call the model once per input instead."
+        )
+
+    def generate_stream(
+        self,
+        model_input: Union[str, Chat],
+        output_type: Optional[OutlinesLogitsProcessor] = None,
+        **kwargs,
+    ) -> Iterator[str]:
+        """Stream text using `mlx-vlm`.
+
+        Parameters
+        ----------
+        model_input
+            The prompt based on which the model will generate a response.
+        output_type
+            Must be `None`. Structured generation is not available with
+            `mlx-vlm`.
+        kwargs
+            Additional keyword arguments to pass to the `mlx-vlm` library.
+
+        Returns
+        -------
+        Iterator[str]
+            An iterator that yields the text generated by the model.
+
+        """
+        self.type_adapter.format_output_type(output_type)
+
+        from mlx_vlm import stream_generate
+
+        formatted_input = self.type_adapter.format_input(model_input)
+
+        for gen_response in stream_generate(
+            self.model,
+            self.processor,
+            formatted_input["prompt"],
+            image=formatted_input["images"],
+            **kwargs,
+        ):
+            yield gen_response.text
+
+
+def from_mlxlm(
+    model: "nn.Module",
+    tokenizer: "Union[MLXTokenizer, ProcessorMixin]",
+) -> Union[MLXLM, MLXLMMultiModal]:
+    """Create an Outlines `MLXLM` or `MLXLMMultiModal` model instance from an
+    `mlx_lm` or `mlx_vlm` model and a tokenizer or processor.
 
     Parameters
     ----------
     model
-        An instance of an `mlx_lm` model.
+        An instance of an `mlx_lm` or `mlx_vlm` model.
     tokenizer
-        An instance of an `mlx_lm` tokenizer or of a compatible
-        transformers tokenizer.
+        An instance of an `mlx_lm` tokenizer, of a compatible transformers
+        tokenizer, or of a `transformers` processor (returned along with the
+        model by `mlx_vlm.load` for vision models).
 
     Returns
     -------
-    MLXLM
-        An Outlines `MLXLM` model instance.
+    Union[MLXLM, MLXLMMultiModal]
+        An Outlines `MLXLM` or `MLXLMMultiModal` model instance.
 
     """
+    from transformers import ProcessorMixin
+
+    if isinstance(tokenizer, ProcessorMixin):
+        return MLXLMMultiModal(model, tokenizer)
     return MLXLM(model, tokenizer)

--- a/tests/backends/test_backends_utils.py
+++ b/tests/backends/test_backends_utils.py
@@ -55,11 +55,11 @@ class NumpyTensorAdapter():
 
 class MLXTensorAdapter():
     def __init__(self):
-        import mlx
-        self.mlx = mlx
+        import mlx.core
+        self.mlx = mlx.core
 
     def randn(self, shape):
-        return self.mlx.random.randn(*shape)
+        return self.mlx.random.normal(shape)
 
     def randint(self, low, high, size):
         return self.mlx.random.randint(low, high, size)

--- a/tests/backends/test_llguidance.py
+++ b/tests/backends/test_llguidance.py
@@ -124,7 +124,7 @@ def test_llguidance_processor_numpy(regex):
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
 def test_llguidance_processor_mlx(regex):
     model = model_mlxlm()
-    tokenizer = model.mlx_tokenizer
+    tokenizer = model.hf_tokenizer
     llg_tokenizer = LLGuidanceBackend(model).llg_tokenizer
     grammar_spec = llguidance.grammar_from("regex", regex)
     processor = LLGuidanceLogitsProcessor(grammar_spec, llg_tokenizer, "mlx")
@@ -132,12 +132,12 @@ def test_llguidance_processor_mlx(regex):
         input_ids = simulate_model_calling_processor(
             processor,
             "mlx",
-            len(tokenizer.vocabulary),
+            len(tokenizer.get_vocab()),
             tokenizer.eos_token_id,
             2
         )
-        assert re.match(regex, tokenizer.decode(input_ids[0]))
-        assert re.match(regex, tokenizer.decode(input_ids[1]))
+        assert re.match(regex, tokenizer.decode(input_ids[0].tolist()))
+        assert re.match(regex, tokenizer.decode(input_ids[1].tolist()))
 
 
 models = [

--- a/tests/backends/test_outlines_core.py
+++ b/tests/backends/test_outlines_core.py
@@ -110,18 +110,18 @@ def test_outlines_core_processor_numpy(regex):
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
-def test_outlines_core_processor_mlx():
+def test_outlines_core_processor_mlx(regex):
     model = model_mlxlm()
-    tokenizer = model.mlx_tokenizer
+    tokenizer = model.hf_tokenizer
     backend = OutlinesCoreBackend(model)
-    index = Index(r"[0-9]{3}", backend.vocabulary)
+    index = Index(regex, backend.vocabulary)
     processor = OutlinesCoreLogitsProcessor(index, "mlx")
     for _ in range(2):
         input_ids = simulate_model_calling_processor(
-            processor, "mlx", len(tokenizer.vocabulary), tokenizer.eos_token_id, 2
+            processor, "mlx", len(tokenizer.get_vocab()), tokenizer.eos_token_id, 2
         )
-        assert re.match(regex, tokenizer.decode(input_ids[0]))
-        assert re.match(regex, tokenizer.decode(input_ids[1]))
+        assert re.match(regex, tokenizer.decode(input_ids[0].tolist()))
+        assert re.match(regex, tokenizer.decode(input_ids[1].tolist()))
 
 
 def test_create_vocabulary_preserves_duplicate_token_ids():

--- a/tests/backends/test_xgrammar.py
+++ b/tests/backends/test_xgrammar.py
@@ -90,9 +90,9 @@ def test_xgr_processor_torch(regex):
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
-def test_xgr_processor_mlx(tokenizer_info):
+def test_xgr_processor_mlx(regex):
     model = model_mlxlm()
-    tokenizer = model.mlx_tokenizer
+    tokenizer = model.hf_tokenizer
     tokenizer_info = TokenizerInfo.from_huggingface(
         tokenizer,
         vocab_size=len(tokenizer.get_vocab())
@@ -108,8 +108,8 @@ def test_xgr_processor_mlx(tokenizer_info):
             tokenizer.eos_token_id,
             2
         )
-        assert re.match(regex, tokenizer.decode(input_ids[0]))
-        assert re.match(regex, tokenizer.decode(input_ids[1]))
+        assert re.match(regex, tokenizer.decode(input_ids[0].tolist()))
+        assert re.match(regex, tokenizer.decode(input_ids[1].tolist()))
 
 
 models = [(model_transformers(), "torch")]

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -3,12 +3,16 @@ import re
 from enum import Enum
 from typing import Generator
 
+from PIL import Image as PILImage
 from pydantic import BaseModel
 import transformers
 
 import outlines
+from outlines.inputs import Chat, Image
 from outlines.models.mlxlm import (
     MLXLM,
+    MLXLMMultiModal,
+    MLXLMMultiModalTypeAdapter,
     MLXLMTypeAdapter,
     from_mlxlm
 )
@@ -23,8 +27,16 @@ try:
 except ImportError:
     HAS_MLX = False
 
+try:
+    import mlx_vlm
+
+    HAS_MLX_VLM = HAS_MLX
+except ImportError:
+    HAS_MLX_VLM = False
+
 
 TEST_MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+TEST_VISION_MODEL = "mlx-community/SmolVLM-256M-Instruct-4bit"
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
@@ -155,3 +167,109 @@ def test_mlxlm_batch_output_type(model):
             ["Respond with one word.", "Respond with one word."],
             Regex(r"[0-9]")
         )
+
+
+@pytest.fixture
+def image():
+    width, height = 128, 128
+    red_background = (255, 0, 0)
+    image = PILImage.new("RGB", (width, height), red_background)
+    image.format = "PNG"
+    return image
+
+
+@pytest.fixture(scope="session")
+def vision_model(tmp_path_factory):
+    model, processor = mlx_vlm.load(TEST_VISION_MODEL)
+    return outlines.from_mlxlm(model, processor)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_model_initialization(vision_model):
+    assert isinstance(vision_model, MLXLMMultiModal)
+    assert isinstance(vision_model, MLXLM)
+    assert isinstance(vision_model.tokenizer, TransformerTokenizer)
+    assert isinstance(vision_model.type_adapter, MLXLMMultiModalTypeAdapter)
+    assert vision_model.tensor_library_name == "mlx"
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_simple(vision_model, image):
+    result = vision_model(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background? One word.", Image(image)],
+        }]),
+        max_tokens=20,
+    )
+    assert isinstance(result, str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_plain_str_input(vision_model):
+    result = vision_model("Respond with one word. Not more.", max_tokens=20)
+    assert isinstance(result, str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_invalid_asset_type(vision_model, image):
+    with pytest.raises(ValueError, match="only supports `Image` assets"):
+        vision_model(
+            Chat([{"role": "user", "content": ["Describe this.", object()]}]),
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_regex(vision_model, image):
+    result = vision_model(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background?", Image(image)],
+        }]),
+        Regex(r"(red|blue|green)"),
+        max_tokens=20,
+    )
+    assert re.fullmatch(r"(red|blue|green)", result)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_json_schema(vision_model, image):
+    class Color(BaseModel):
+        color: str
+
+    result = vision_model(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background?", Image(image)],
+        }]),
+        Color,
+        max_tokens=30,
+    )
+    assert "color" in result
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_stream(vision_model, image):
+    generator = vision_model.stream(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background? One word.", Image(image)],
+        }]),
+        max_tokens=20,
+    )
+    assert isinstance(generator, Generator)
+    assert isinstance(next(generator), str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_batch_not_implemented(vision_model, image):
+    with pytest.raises(
+        NotImplementedError,
+        match="mlx-vlm does not support batch generation"
+    ):
+        vision_model.batch([
+            Chat([{
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            }]),
+        ])

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -3,12 +3,16 @@ import re
 from enum import Enum
 from typing import Generator
 
+from PIL import Image as PILImage
 from pydantic import BaseModel
 import transformers
 
 import outlines
+from outlines.inputs import Chat, Image
 from outlines.models.mlxlm import (
     MLXLM,
+    MLXLMMultiModal,
+    MLXLMMultiModalTypeAdapter,
     MLXLMTypeAdapter,
     from_mlxlm
 )
@@ -23,8 +27,16 @@ try:
 except ImportError:
     HAS_MLX = False
 
+try:
+    import mlx_vlm
+
+    HAS_MLX_VLM = HAS_MLX
+except ImportError:
+    HAS_MLX_VLM = False
+
 
 TEST_MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+TEST_VISION_MODEL = "mlx-community/SmolVLM-256M-Instruct-4bit"
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
@@ -42,8 +54,6 @@ def test_mlxlm_model_initialization():
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
 def test_mlxlm_model_initialization_with_hf_tokenizer():
-    """from_mlxlm must work when a raw HF tokenizer is passed instead of a
-    mlx_lm.TokenizerWrapper."""
     mlx_model, _ = mlx_lm.load(TEST_MODEL)
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained(TEST_MODEL)
     model = from_mlxlm(mlx_model, hf_tokenizer)
@@ -155,3 +165,105 @@ def test_mlxlm_batch_output_type(model):
             ["Respond with one word.", "Respond with one word."],
             Regex(r"[0-9]")
         )
+
+
+@pytest.fixture
+def image():
+    width, height = 128, 128
+    red_background = (255, 0, 0)
+    image = PILImage.new("RGB", (width, height), red_background)
+    image.format = "PNG"
+    return image
+
+
+@pytest.fixture(scope="session")
+def vision_model(tmp_path_factory):
+    model, processor = mlx_vlm.load(TEST_VISION_MODEL)
+    return outlines.from_mlxlm(model, processor)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_model_initialization(vision_model):
+    assert isinstance(vision_model, MLXLMMultiModal)
+    assert isinstance(vision_model, MLXLM)
+    assert isinstance(vision_model.tokenizer, TransformerTokenizer)
+    assert isinstance(vision_model.type_adapter, MLXLMMultiModalTypeAdapter)
+    assert vision_model.tensor_library_name == "mlx"
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_simple(vision_model, image):
+    result = vision_model(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background? One word.", Image(image)],
+        }]),
+        max_tokens=20,
+    )
+    assert isinstance(result, str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_plain_str_input(vision_model):
+    result = vision_model("Respond with one word. Not more.", max_tokens=20)
+    assert isinstance(result, str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_invalid_asset_type(vision_model, image):
+    with pytest.raises(ValueError, match="only supports `Image` assets"):
+        vision_model(
+            Chat([{"role": "user", "content": ["Describe this.", object()]}]),
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_output_type_not_implemented(vision_model, image):
+    with pytest.raises(NotImplementedError, match="structured generation"):
+        vision_model(
+            Chat([{
+                "role": "user",
+                "content": ["What color is the background?", Image(image)],
+            }]),
+            Regex(r"(red|blue|green)"),
+            max_tokens=20,
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_stream_output_type_not_implemented(vision_model):
+    with pytest.raises(NotImplementedError, match="structured generation"):
+        next(
+            vision_model.stream(
+                "Respond with one word. Not more.",
+                Regex(r"(red|blue|green)"),
+                max_tokens=20,
+            )
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_stream(vision_model, image):
+    generator = vision_model.stream(
+        Chat([{
+            "role": "user",
+            "content": ["What color is the background? One word.", Image(image)],
+        }]),
+        max_tokens=20,
+    )
+    assert isinstance(generator, Generator)
+    assert isinstance(next(generator), str)
+
+
+@pytest.mark.skipif(not HAS_MLX_VLM, reason="MLX-VLM tests require Apple Silicon")
+def test_mlxlm_vision_batch_not_implemented(vision_model, image):
+    with pytest.raises(
+        NotImplementedError,
+        match="mlx-vlm does not support batch generation"
+    ):
+        vision_model.batch([
+            Chat([{
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            }]),
+        ])

--- a/tests/models/test_mlxlm_type_adapter.py
+++ b/tests/models/test_mlxlm_type_adapter.py
@@ -1,13 +1,18 @@
-import pytest
 import io
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from outlines_core import Index, Vocabulary
 from PIL import Image as PILImage
 
 from outlines.backends.outlines_core import OutlinesCoreLogitsProcessor
 from outlines.inputs import Chat, Image
-from outlines.models.mlxlm import MLXLMTypeAdapter
+from outlines.models.mlxlm import (
+    MLXLMMultiModalTypeAdapter,
+    MLXLMTypeAdapter,
+)
 
 try:
     import mlx_lm
@@ -73,6 +78,156 @@ def test_mlxlm_type_adapter_format_input_without_template():
     result = adapter.format_input(message)
 
     assert result == "prompt"
+
+
+@pytest.mark.parametrize(
+    ("model_type", "formatted_prompt"),
+    [
+        ("gemma3", "Describe this.<start_of_image>"),
+        ("phi3_v", "<|image_1|>Describe this."),
+        ("paligemma", "<image>Describe this."),
+    ],
+)
+def test_mlxlm_multimodal_type_adapter_uses_model_prompt_formatter(
+    monkeypatch, image, model_type, formatted_prompt
+):
+    processor = MagicMock()
+    config = SimpleNamespace(model_type=model_type)
+    formatter = MagicMock(return_value=formatted_prompt)
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.apply_chat_template = formatter
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=processor,
+        config=config,
+    )
+    image_asset = Image(image)
+    result = adapter.format_input(Chat([{
+        "role": "user",
+        "content": ["Describe this.", image_asset],
+    }]))
+
+    assert result == {
+        "prompt": formatted_prompt,
+        "images": [image_asset.image],
+    }
+    formatter.assert_called_once_with(
+        processor,
+        config,
+        [{"role": "user", "content": "Describe this."}],
+        num_images=1,
+    )
+
+
+def test_mlxlm_multimodal_type_adapter_rejects_output_type():
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=MagicMock(),
+        config=SimpleNamespace(model_type="smolvlm"),
+    )
+
+    assert adapter.format_output_type(None) is None
+    with pytest.raises(NotImplementedError, match="structured generation"):
+        adapter.format_output_type(MagicMock())
+
+
+def test_mlxlm_multimodal_type_adapter_rejects_later_turn_images(
+    monkeypatch, image
+):
+    formatter = MagicMock(return_value="formatted_prompt")
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.apply_chat_template = formatter
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=MagicMock(),
+        config=SimpleNamespace(model_type="smolvlm"),
+    )
+
+    with pytest.raises(ValueError, match="first user message"):
+        adapter.format_input(Chat([
+            {"role": "user", "content": "Remember this."},
+            {"role": "assistant", "content": "Okay."},
+            {
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            },
+        ]))
+
+    formatter.assert_not_called()
+
+
+def test_mlxlm_multimodal_type_adapter_rejects_images_after_two_messages(
+    monkeypatch, image
+):
+    formatter = MagicMock(return_value="formatted_prompt")
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.apply_chat_template = formatter
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=MagicMock(),
+        config=SimpleNamespace(model_type="smolvlm"),
+    )
+
+    with pytest.raises(ValueError, match="first or second message"):
+        adapter.format_input(Chat([
+            {"role": "system", "content": "First instruction."},
+            {"role": "system", "content": "Second instruction."},
+            {
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            },
+        ]))
+
+    formatter.assert_not_called()
+
+
+def test_mlxlm_multimodal_type_adapter_rejects_two_leading_user_messages(
+    monkeypatch, image
+):
+    formatter = MagicMock(return_value="formatted_prompt")
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.apply_chat_template = formatter
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=MagicMock(),
+        config=SimpleNamespace(model_type="smolvlm"),
+    )
+
+    with pytest.raises(ValueError, match="first two messages"):
+        adapter.format_input(Chat([
+            {
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            },
+            {"role": "user", "content": "Focus on the background."},
+        ]))
+
+    formatter.assert_not_called()
+
+
+@pytest.mark.parametrize("model_type", ["paligemma", "molmo", "florence2"])
+def test_mlxlm_multimodal_type_adapter_rejects_prompt_only_chat_history(
+    monkeypatch, image, model_type
+):
+    formatter = MagicMock(return_value="formatted_prompt")
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.apply_chat_template = formatter
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    adapter = MLXLMMultiModalTypeAdapter(
+        processor=MagicMock(),
+        config=SimpleNamespace(model_type=model_type),
+    )
+
+    with pytest.raises(ValueError, match="single user message"):
+        adapter.format_input(Chat([
+            {
+                "role": "user",
+                "content": ["Describe this.", Image(image)],
+            },
+            {"role": "assistant", "content": "Prior answer."},
+        ]))
+
+    formatter.assert_not_called()
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -269,6 +278,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d2/2cde336b375f55c76ca670f0be3978cc048e31e24f3b4d7ce8473150a388/cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be", size = 183779, upload-time = "2026-08-03T21:19:15.602Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1a/4b2f7c92293ba05cbd4a9a1b28faaf0326272d9488e6354657571c48a7aa/cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b", size = 184178, upload-time = "2026-08-03T21:19:16.67Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0b/ba385d8ccedf926c3cd06e8e2f327027da5afe5f0eb30f1f7bc43ac55125/cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004", size = 211037, upload-time = "2026-08-03T21:19:17.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b9/0f2e58b2cefa33255bff36935d42b13180fe559bba82596540eb404bde7d/cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9", size = 218652, upload-time = "2026-08-03T21:19:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/37/15/180e0dab27b9312c7479003d14c9e547634b7dcb934e2cc4650e1b131a7a/cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98", size = 205422, upload-time = "2026-08-03T21:19:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/03026f0c850cbbaa9030750490225b4a7f4d524ea4df72c3cc740a90f4ef/cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9", size = 205444, upload-time = "2026-08-03T21:19:21.246Z" },
+    { url = "https://files.pythonhosted.org/packages/75/77/60bebf6f818bec84210ac5b6979ce4eeadce6fbbaabc9c7ab23e506d1ce5/cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6", size = 218742, upload-time = "2026-08-03T21:19:22.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/679bf47e73fd77b352171727f07de559a003f14de5d02b904a6ec1fa73ca/cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf", size = 221054, upload-time = "2026-08-03T21:19:23.694Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/eefc0e06913b70aa153bf74c946094a18f58fd4aff11b7f372bfdfdca050/cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659", size = 213489, upload-time = "2026-08-03T21:19:24.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/13/4e56852824a03cdf68523a35686f1c28eacd4bd30a7b0a78e682e6e6e1d3/cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9", size = 220241, upload-time = "2026-08-03T21:19:26.214Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7f/040f9e163e4acac3ee3d85b02d00b2576e7ca980d8785f0a3a5f1a9bf7f5/cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41", size = 174578, upload-time = "2026-08-03T21:19:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0b/644a2ec1a4eaba49c2939410bb1eb1d25b09d6d0582f5d2f95c537043725/cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1", size = 185082, upload-time = "2026-08-03T21:19:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
 ]
 
 [[package]]
@@ -651,6 +722,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -1733,6 +1820,29 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx-vlm"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasets" },
+    { name = "fastapi" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "requests" },
+    { name = "soundfile" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/98/6b3c2d1317a317d0df544fe9ab0ef4f233ea85c1e4ac2fe6af7289ea1ee5/mlx_vlm-0.3.9.tar.gz", hash = "sha256:ae5050d0b1a051a29099c3a65efdbf6874bb497e8465734ac1992b6b179135b4", size = 303350, upload-time = "2025-12-03T21:48:24.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/d13985f2c42919d23d71549c92063ca749bfa6eea706fb08c14b6b5a0053/mlx_vlm-0.3.9-py3-none-any.whl", hash = "sha256:fa94a450161ae3978ca71565b5364c4ce0e86f0c1fae98a24afaa43feb121c57", size = 398621, upload-time = "2025-12-03T21:48:22.691Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2289,6 +2399,25 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8a/b04776ec45d2dea08a1b176f1829201db3515d4ed16c35f8fcc9fa7beb16/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2b4272e736836f66c2d176e43ab8101f3a00d45654916399f52e150c58981ac", size = 50614064, upload-time = "2026-07-02T06:53:22.604Z" },
+    { url = "https://files.pythonhosted.org/packages/95/54/eb47866b94f2b5b42dde17644b78055ef1ee05aae59962c7290e55270803/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8b6d0a212253dd26ad338c812f1f23ca118fdf05a9c8c6b9444f161aa8c5881", size = 71064711, upload-time = "2026-07-02T06:54:13.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/da/962579f1e703cbf8c5422fd1f576467dcb3b5b0b0b81c1471c979764353a/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:08d5d91d967b58d6db86073b2ad3eaef88ca4ebdfd45c9059bf59f5ded0c7ad2", size = 49798576, upload-time = "2026-07-02T06:54:33.781Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4c/c73f828fdbcd37eaf21d08fa852544a3ca7c2dbb3ea76873d64f2ea413d1/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8de2dec111122a02e8beb28e16c31904992dfd6186560b142a92c71403c1039", size = 73783032, upload-time = "2026-07-02T06:55:03.415Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4b/edaf83b996ca5a1a3d8ccad485706b9c6d4742b13b9c4586bf1c1e7d9423/opencv_python-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:4b4b1a34c79bf8d3738e3cfe9a9e67b51a79663f6b692cbdad8c31f570da4157", size = 35564734, upload-time = "2026-07-02T05:49:57.704Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f0/9fa6e85cb10c8eb36a0222d27e50fe381b86ce49a55446bf39f491727564/opencv_python-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:f90ba04b8f73bc5c3814037699739f0156f597338a98f05956c684e7c3ca10d2", size = 44000345, upload-time = "2026-07-02T05:49:54.971Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2466,6 +2595,7 @@ mlxlm = [
     { name = "datasets" },
     { name = "mlx" },
     { name = "mlx-lm" },
+    { name = "mlx-vlm" },
 ]
 ollama = [
     { name = "ollama" },
@@ -2498,6 +2628,7 @@ test = [
     { name = "mistralai" },
     { name = "mkdocs-gen-files" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numba" },
     { name = "numpy" },
     { name = "ollama" },
@@ -2581,6 +2712,8 @@ requires-dist = [
     { name = "mlx", marker = "extra == 'mlxlm'" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'test'", specifier = ">=0.19.2" },
     { name = "mlx-lm", marker = "extra == 'mlxlm'" },
+    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'test'" },
+    { name = "mlx-vlm", marker = "extra == 'mlxlm'" },
     { name = "numba", marker = "extra == 'llamacpp'" },
     { name = "numba", marker = "extra == 'test'" },
     { name = "numpy", marker = "extra == 'test'", specifier = ">=2.0.0,<2.2.0" },
@@ -3012,6 +3145,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -3783,6 +3925,40 @@ wheels = [
 ]
 
 [[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4181,6 +4357,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/53/be79eff13cc289570b4c6875fa4641a91a1dc51ece7f6213f364b0a58c4c/uvicorn-0.52.2.tar.gz", hash = "sha256:4294500b9c8f7a3ef3e975d9e4be08c3eb76441af449a9e6e10146c6a182ffec", size = 100685, upload-time = "2026-08-13T07:03:57.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/08/0d834cf3e61e476c9f422e856a9e37d12d708d7ada942a2774b1f42aee6c/uvicorn-0.52.2-py3-none-any.whl", hash = "sha256:0b916d247cf5500b320638ea11abf0fed7f348e8e1c7fde53a0e6b6319803512", size = 79912, upload-time = "2026-08-13T07:03:55.658Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1188.

This adds vision-model support through `mlx-vlm` while preserving the existing text-only `MLXLM` path.

`from_mlxlm` now dispatches on its second argument:

- an MLX or Transformers tokenizer returns `MLXLM`;
- a Transformers processor returns the new `MLXLMMultiModal` wrapper.

The multimodal wrapper follows the existing `TransformersMultiModal` split. It accepts `Chat` inputs with `Image` assets, formats them with the processor's chat template, and uses `mlx_vlm.generate` or `mlx_vlm.stream_generate`. Plain string inputs, constrained generation, and streaming are supported. Vision batching raises `NotImplementedError` because the current `mlx-vlm` batching API does not fit Outlines' existing `generate_batch` contract.

Both wrappers expose the underlying Hugging Face tokenizer through `hf_tokenizer`, so the outlines-core, XGrammar, and llguidance backends can build their vocabularies without depending on whether the loader returned a tokenizer or processor.

`mlx-vlm` is included in the existing `mlxlm` extra so the loader has one installation path for text and vision models.

Verification:

- 22 MLX-LM and MLX-VLM tests pass.
- An Apple Silicon smoke test with `mlx-community/SmolVLM-256M-Instruct-4bit` covered unconstrained, regex-constrained, JSON-schema, and streaming generation on a real image.
- Pre-commit passes.
