### PR TITLE
fix: resolve $ref and combinator keywords in JSON Schema to Python conversion

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -115,6 +115,15 @@ def schema_type_to_python(
     Any
         The Python type
 
+    Notes
+    -----
+    The back edge of a recursive schema is intentionally left unconstrained,
+    as ``Optional[Any]``. It is the designed stopping point rather than a
+    missed conversion: a finite regex cannot express an unbounded tree, and
+    null is the only way an instance of a required self-reference can
+    terminate. Narrowing it to a bare ``Any`` would produce a property with no
+    ``type``, which the regex backend rejects.
+
     """
     # ``$defs`` live on the top-level schema, so the root has to travel with
     # the recursion; without it a nested ``$ref`` has nothing to resolve against.
@@ -123,11 +132,20 @@ def schema_type_to_python(
 
     if "$ref" in schema:
         ref = schema["$ref"]
-        # A recursive schema (a model referencing itself, directly or through
-        # a cycle) has no finite Python type here, so the cycle is broken with
-        # ``Any`` rather than recursing until the stack runs out.
+        # A recursive schema (a model referencing itself, directly or through a
+        # cycle) has no finite Python type here, so the back edge is left
+        # deliberately unconstrained rather than recursing until the stack runs
+        # out. This is the designed stopping point, not a missed conversion: a
+        # finite regex cannot express an unbounded tree.
+        #
+        # ``Optional[Any]`` rather than ``Any``, because the back edge has to
+        # round-trip to a schema the regex backend accepts. A bare ``Any``
+        # serializes to a property with no ``type`` (``{"title": "Next"}``),
+        # which ``to_regex`` rejects outright; ``Optional[Any]`` serializes to
+        # ``{"anyOf": [{}, {"type": "null"}]}``, which it accepts. Null is also
+        # the only way an instance of a *required* self-reference can terminate.
         if ref in _seen:
-            return Any
+            return Optional[Any]
         resolved = _resolve_ref(ref, root)
         if resolved is None:
             return Any
@@ -135,6 +153,11 @@ def schema_type_to_python(
             resolved, caller_target_type, root=root, _seen=_seen | {ref}
         )
 
+    # A member that is not a dict is not a subschema. Every combinator drops
+    # those and falls back to ``Any`` once nothing valid is left, rather than
+    # raising: an unusable member should not make the whole schema unusable.
+    # This is separate from a well-formed ``allOf`` of several object
+    # subschemas, which is left as ``Any`` for the reason given below.
     for keyword in ("anyOf", "oneOf"):
         if keyword in schema:
             members = tuple(

--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -12,9 +12,88 @@ else:  # pragma: no cover
     from typing_extensions import _TypedDictMeta, NotRequired, TypedDict  # type: ignore
 
 
+def _resolve_ref(ref: str, root: dict) -> Optional[dict]:
+    """Resolve a local JSON Pointer against the root schema.
+
+    Only local references are resolvable: ``#``, ``#/$defs/Name``,
+    ``#/definitions/Name``. Remote references (a URI, or a pointer into
+    another document) return ``None`` and the caller falls back to ``Any``.
+
+    Parameters
+    ----------
+    ref: str
+        The value of a ``$ref`` keyword
+    root: dict
+        The schema the pointer is resolved against
+
+    Returns
+    -------
+    Optional[dict]
+        The referenced subschema, or None if it is not a resolvable local ref
+
+    """
+    if not ref.startswith("#"):
+        return None
+
+    pointer = ref[1:].lstrip("/")
+    if not pointer:
+        return root
+
+    target: Any = root
+    for token in pointer.split("/"):
+        # JSON Pointer escapes, RFC 6901: ~1 is '/', ~0 is '~'.
+        token = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(target, dict) or token not in target:
+            return None
+        target = target[token]
+
+    return target if isinstance(target, dict) else None
+
+
+def _deref_root(
+    schema: dict, root: dict, _seen: frozenset
+) -> tuple[dict, frozenset]:
+    """Follow top-level ``$ref`` keywords to the subschema holding the properties.
+
+    Pydantic emits ``{"$defs": {...}, "$ref": "#/$defs/Model"}`` for a
+    self-referential model, so the object being converted is one indirection
+    away from the document root. Reading ``properties`` off the document
+    directly yields nothing.
+
+    Parameters
+    ----------
+    schema: dict
+        The schema to dereference
+    root: dict
+        The schema the pointer is resolved against
+    _seen: frozenset
+        The ``$ref`` pointers already followed
+
+    Returns
+    -------
+    tuple[dict, frozenset]
+        The dereferenced schema and the updated set of followed pointers
+
+    """
+    while "$ref" in schema:
+        ref = schema["$ref"]
+        if ref in _seen:
+            break
+        resolved = _resolve_ref(ref, root)
+        if resolved is None:
+            break
+        schema = resolved
+        _seen = _seen | {ref}
+
+    return schema, _seen
+
+
 def schema_type_to_python(
     schema: dict,
-    caller_target_type: Literal["pydantic", "typeddict", "dataclass"]
+    caller_target_type: Literal["pydantic", "typeddict", "dataclass"],
+    *,
+    root: Optional[dict] = None,
+    _seen: frozenset = frozenset(),
 ) -> Any:
     """Get a Python type from a JSON Schema dict.
 
@@ -24,6 +103,12 @@ def schema_type_to_python(
         The JSON Schema dict to convert to a Python type
     caller_target_type: Literal["pydantic", "typeddict", "dataclass"]
         The type of the caller
+    root: Optional[dict]
+        The top-level schema, against which ``$ref`` pointers are resolved.
+        Defaults to ``schema`` itself, so a top-level call needs no argument.
+    _seen: frozenset
+        The ``$ref`` pointers currently being resolved, used to stop a
+        self-referential schema from recursing forever.
 
     Returns
     -------
@@ -31,6 +116,48 @@ def schema_type_to_python(
         The Python type
 
     """
+    # ``$defs`` live on the top-level schema, so the root has to travel with
+    # the recursion; without it a nested ``$ref`` has nothing to resolve against.
+    if root is None:
+        root = schema
+
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        # A recursive schema (a model referencing itself, directly or through
+        # a cycle) has no finite Python type here, so the cycle is broken with
+        # ``Any`` rather than recursing until the stack runs out.
+        if ref in _seen:
+            return Any
+        resolved = _resolve_ref(ref, root)
+        if resolved is None:
+            return Any
+        return schema_type_to_python(
+            resolved, caller_target_type, root=root, _seen=_seen | {ref}
+        )
+
+    for keyword in ("anyOf", "oneOf"):
+        if keyword in schema:
+            members = tuple(
+                schema_type_to_python(
+                    subschema, caller_target_type, root=root, _seen=_seen
+                )
+                for subschema in schema[keyword]
+                if isinstance(subschema, dict)
+            )
+            return Union[members] if members else Any  # type: ignore
+
+    if "allOf" in schema:
+        subschemas = [s for s in schema["allOf"] if isinstance(s, dict)]
+        # A single-element ``allOf`` is just an alias for its one subschema —
+        # the form Pydantic emits for a ``$ref`` carrying sibling metadata.
+        # Merging two or more subschemas is a different problem (conflicting
+        # keywords, competing ``required`` sets) and is left as ``Any``.
+        if len(subschemas) == 1:
+            return schema_type_to_python(
+                subschemas[0], caller_target_type, root=root, _seen=_seen
+            )
+        return Any
+
     if "enum" in schema:
         values = schema["enum"]
         return Literal[tuple(values)]
@@ -50,7 +177,10 @@ def schema_type_to_python(
         # Python type and combine them into a Union (mirroring the ``anyOf``
         # the regex backend uses for type arrays).
         members = tuple(
-            schema_type_to_python({**schema, "type": member}, caller_target_type)
+            schema_type_to_python(
+                {**schema, "type": member}, caller_target_type,
+                root=root, _seen=_seen,
+            )
             for member in t
         )
         return Union[members] if members else Any  # type: ignore
@@ -67,26 +197,31 @@ def schema_type_to_python(
         return type(None)
     elif t == "array":
         items = schema.get("items", {})
-        if items:
-            item_type = schema_type_to_python(items, caller_target_type)
+        if isinstance(items, dict) and items:
+            item_type = schema_type_to_python(
+                items, caller_target_type, root=root, _seen=_seen
+            )
         else:
             item_type = Any
         return List[item_type]  # type: ignore
     elif t == "object":
         name = schema.get("title")
         if caller_target_type == "pydantic":
-            return json_schema_dict_to_pydantic(schema, name)
+            return json_schema_dict_to_pydantic(schema, name, root=root, _seen=_seen)
         elif caller_target_type == "typeddict":
-            return json_schema_dict_to_typeddict(schema, name)
+            return json_schema_dict_to_typeddict(schema, name, root=root, _seen=_seen)
         elif caller_target_type == "dataclass":
-            return json_schema_dict_to_dataclass(schema, name)
+            return json_schema_dict_to_dataclass(schema, name, root=root, _seen=_seen)
 
     return Any
 
 
 def json_schema_dict_to_typeddict(
     schema: dict,
-    name: Optional[str] = None
+    name: Optional[str] = None,
+    *,
+    root: Optional[dict] = None,
+    _seen: frozenset = frozenset(),
 ) -> _TypedDictMeta:
     """Convert a JSON Schema dict into a TypedDict class.
 
@@ -96,6 +231,11 @@ def json_schema_dict_to_typeddict(
         The JSON Schema dict to convert to a TypedDict
     name: Optional[str]
         The name of the TypedDict
+    root: Optional[dict]
+        The top-level schema ``$ref`` pointers resolve against. Defaults to
+        ``schema`` itself.
+    _seen: frozenset
+        The ``$ref`` pointers currently being resolved.
 
     Returns
     -------
@@ -103,13 +243,18 @@ def json_schema_dict_to_typeddict(
         The TypedDict class
 
     """
+    if root is None:
+        root = schema
+
+    schema, _seen = _deref_root(schema, root, _seen)
+
     required = set(schema.get("required", []))
     properties = schema.get("properties", {})
 
     annotations: Dict[str, Any] = {}
 
     for property, details in properties.items():
-        typ = schema_type_to_python(details, "typeddict")
+        typ = schema_type_to_python(details, "typeddict", root=root, _seen=_seen)
         if property not in required:
             # NotRequired (PEP 655) marks the KEY optional; Optional only makes the
             # value nullable, leaving the key required on a total=True TypedDict.
@@ -121,7 +266,10 @@ def json_schema_dict_to_typeddict(
 
 def json_schema_dict_to_pydantic(
     schema: dict,
-    name: Optional[str] = None
+    name: Optional[str] = None,
+    *,
+    root: Optional[dict] = None,
+    _seen: frozenset = frozenset(),
 ) -> type[BaseModel]:
     """Convert a JSON Schema dict into a Pydantic BaseModel class.
 
@@ -131,6 +279,11 @@ def json_schema_dict_to_pydantic(
         The JSON Schema dict to convert to a Pydantic BaseModel
     name: Optional[str]
         The name of the Pydantic BaseModel
+    root: Optional[dict]
+        The top-level schema ``$ref`` pointers resolve against. Defaults to
+        ``schema`` itself.
+    _seen: frozenset
+        The ``$ref`` pointers currently being resolved.
 
     Returns
     -------
@@ -138,13 +291,18 @@ def json_schema_dict_to_pydantic(
         The Pydantic BaseModel class
 
     """
+    if root is None:
+        root = schema
+
+    schema, _seen = _deref_root(schema, root, _seen)
+
     required = set(schema.get("required", []))
     properties = schema.get("properties", {})
 
     field_definitions: Dict[str, Any] = {}
 
     for property, details in properties.items():
-        typ = schema_type_to_python(details, "pydantic")
+        typ = schema_type_to_python(details, "pydantic", root=root, _seen=_seen)
         if property not in required:
             field_definitions[property] = (Optional[typ], None)
         else:
@@ -155,7 +313,10 @@ def json_schema_dict_to_pydantic(
 
 def json_schema_dict_to_dataclass(
     schema: dict,
-    name: Optional[str] = None
+    name: Optional[str] = None,
+    *,
+    root: Optional[dict] = None,
+    _seen: frozenset = frozenset(),
 ) -> type:
     """Convert a JSON Schema dict into a dataclass.
 
@@ -165,6 +326,11 @@ def json_schema_dict_to_dataclass(
         The JSON Schema dict to convert to a dataclass
     name: Optional[str]
         The name of the dataclass
+    root: Optional[dict]
+        The top-level schema ``$ref`` pointers resolve against. Defaults to
+        ``schema`` itself.
+    _seen: frozenset
+        The ``$ref`` pointers currently being resolved.
 
     Returns
     -------
@@ -172,6 +338,11 @@ def json_schema_dict_to_dataclass(
         The dataclass
 
     """
+    if root is None:
+        root = schema
+
+    schema, _seen = _deref_root(schema, root, _seen)
+
     required = set(schema.get("required", []))
     properties = schema.get("properties", {})
 
@@ -179,7 +350,7 @@ def json_schema_dict_to_dataclass(
     defaults: Dict[str, Any] = {}
 
     for property, details in properties.items():
-        typ = schema_type_to_python(details, "dataclass")
+        typ = schema_type_to_python(details, "dataclass", root=root, _seen=_seen)
         annotations[property] = typ
 
         if property not in required:

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -415,3 +415,169 @@ def test_json_schema_dict_to_dataclass_optional_before_required():
     instance = result(user_id=5)
     assert instance.user_id == 5
     assert instance.nickname is None
+
+
+def test_schema_type_to_python_local_ref():
+    schema = {
+        "type": "object",
+        "properties": {"address": {"$ref": "#/$defs/Address"}},
+        "required": ["address"],
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            }
+        },
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Person")
+    address = result.model_fields["address"].annotation
+    assert issubclass(address, BaseModel)
+    assert address.model_fields["city"].annotation is str
+
+
+def test_schema_type_to_python_ref_definitions_keyword():
+    # Draft-07 uses "definitions" where 2020-12 uses "$defs".
+    schema = {
+        "type": "object",
+        "properties": {"count": {"$ref": "#/definitions/Count"}},
+        "required": ["count"],
+        "definitions": {"Count": {"type": "integer"}},
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Model")
+    assert result.model_fields["count"].annotation is int
+
+
+def test_schema_type_to_python_unresolvable_ref():
+    # A remote ref and a dangling pointer are both left as Any rather than
+    # raising, so an unsupported schema degrades instead of breaking.
+    remote = {"$ref": "https://example.com/schema.json"}
+    dangling = {"$ref": "#/$defs/Missing"}
+
+    assert schema_type_to_python(remote, "pydantic") is Any
+    assert schema_type_to_python(dangling, "pydantic") is Any
+
+
+def test_json_schema_dict_to_pydantic_root_ref():
+    # Pydantic emits a top-level $ref for a self-referential model; the
+    # properties live one indirection away from the document root.
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"],
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Node")
+    assert result.model_fields["value"].annotation is int
+
+
+def test_json_schema_dict_to_pydantic_recursive_ref():
+    # A cycle has no finite Python type, so it resolves to Any instead of
+    # recursing until the stack runs out.
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "integer"},
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Node"},
+                    },
+                },
+                "required": ["value"],
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+
+    result = json_schema_dict_to_pydantic(schema, "Node")
+    assert result.model_fields["value"].annotation is int
+    assert result.model_fields["children"].annotation == Optional[List[Any]]
+
+
+def test_schema_type_to_python_any_of():
+    schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+    assert schema_type_to_python(schema, "pydantic") == Union[str, int]
+
+
+def test_schema_type_to_python_one_of():
+    schema = {"oneOf": [{"type": "string"}, {"type": "null"}]}
+    assert schema_type_to_python(schema, "pydantic") == Optional[str]
+
+
+def test_schema_type_to_python_all_of_single():
+    # A one-element allOf is an alias for its subschema. Two or more require
+    # merging competing keywords and stay Any.
+    assert schema_type_to_python({"allOf": [{"type": "integer"}]}, "pydantic") is int
+    assert (
+        schema_type_to_python(
+            {"allOf": [{"type": "integer"}, {"type": "string"}]}, "pydantic"
+        )
+        is Any
+    )
+
+
+def test_json_schema_dict_to_typeddict_ref():
+    schema = {
+        "type": "object",
+        "properties": {"address": {"$ref": "#/$defs/Address"}},
+        "required": ["address"],
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            }
+        },
+    }
+
+    result = json_schema_dict_to_typeddict(schema, "Person")
+    assert isinstance(result, _TypedDictMeta)
+    assert isinstance(result.__annotations__["address"], _TypedDictMeta)
+
+
+def test_json_schema_dict_to_dataclass_ref():
+    schema = {
+        "type": "object",
+        "properties": {"address": {"$ref": "#/$defs/Address"}},
+        "required": ["address"],
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            }
+        },
+    }
+
+    result = json_schema_dict_to_dataclass(schema, "Person")
+    assert is_dataclass(result)
+    assert is_dataclass(result.__annotations__["address"])
+
+
+def test_pydantic_nested_model_round_trip():
+    # The end-to-end case: a nested Pydantic model serialized to JSON Schema
+    # and converted back must keep its nested structure.
+    class Address(BaseModel):
+        street: str
+        city: str
+
+    class Person(BaseModel):
+        name: str
+        address: Address
+
+    result = json_schema_dict_to_pydantic(Person.model_json_schema(), "Person")
+    address = result.model_fields["address"].annotation
+
+    assert result.model_fields["name"].annotation is str
+    assert issubclass(address, BaseModel)
+    assert address.model_fields["street"].annotation is str
+    assert address.model_fields["city"].annotation is str

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -2,9 +2,11 @@ import sys
 from dataclasses import is_dataclass
 from typing import Any, List, Literal, Optional, Union
 
+import pytest
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticUndefined
 
+from outlines.types.dsl import JsonSchema, to_regex
 from outlines.types.json_schema_utils import (
     schema_type_to_python,
     json_schema_dict_to_typeddict,
@@ -500,7 +502,9 @@ def test_json_schema_dict_to_pydantic_recursive_ref():
 
     result = json_schema_dict_to_pydantic(schema, "Node")
     assert result.model_fields["value"].annotation is int
-    assert result.model_fields["children"].annotation == Optional[List[Any]]
+    # The item type is the back edge, left unconstrained so the cycle ends.
+    assert result.model_fields["children"].annotation == Optional[List[Optional[Any]]]
+    assert to_regex(JsonSchema(result))
 
 
 def test_schema_type_to_python_any_of():
@@ -581,3 +585,83 @@ def test_pydantic_nested_model_round_trip():
     assert issubclass(address, BaseModel)
     assert address.model_fields["street"].annotation is str
     assert address.model_fields["city"].annotation is str
+
+
+def _recursive_schema(required_back_edge: bool) -> dict:
+    required = ["value", "next"] if required_back_edge else ["value"]
+    return {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "integer"},
+                    "next": {"$ref": "#/$defs/Node"},
+                },
+                "required": required,
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+
+
+@pytest.mark.parametrize("required_back_edge", [True, False])
+def test_recursive_schema_round_trips_through_to_regex(required_back_edge):
+    """The back edge must serialize to a shape the regex backend accepts.
+
+    A bare ``Any`` round-trips to a property with no ``type``, which
+    ``to_regex`` rejects, so converting a recursive schema has to leave the
+    back edge as ``Optional[Any]``. Asserting on the annotation alone would
+    not catch a regression here.
+    """
+    model = json_schema_dict_to_pydantic(
+        _recursive_schema(required_back_edge), "Node"
+    )
+
+    assert model.model_fields["value"].annotation is int
+    assert model.model_fields["next"].annotation == Optional[Any]
+
+    # The whole point: this must not raise.
+    assert to_regex(JsonSchema(model))
+
+
+def test_mutually_recursive_schema_round_trips_through_to_regex():
+    schema = {
+        "$defs": {
+            "A": {
+                "type": "object",
+                "properties": {"b": {"$ref": "#/$defs/B"}},
+                "required": ["b"],
+            },
+            "B": {
+                "type": "object",
+                "properties": {"a": {"$ref": "#/$defs/A"}},
+                "required": ["a"],
+            },
+        },
+        "$ref": "#/$defs/A",
+    }
+
+    model = json_schema_dict_to_pydantic(schema, "A")
+    assert to_regex(JsonSchema(model))
+
+
+def test_nested_model_round_trips_through_to_regex():
+    """Before $ref resolution this raised rather than losing constraints."""
+
+    class Address(BaseModel):
+        street: str
+        city: str
+
+    class Person(BaseModel):
+        name: str
+        address: Address
+
+    model = json_schema_dict_to_pydantic(Person.model_json_schema(), "Person")
+    assert to_regex(JsonSchema(model))
+
+
+@pytest.mark.parametrize("keyword", ["anyOf", "oneOf", "allOf"])
+def test_combinator_drops_non_dict_members(keyword):
+    """A member that is not a subschema is dropped by every combinator."""
+    assert schema_type_to_python({keyword: [{"type": "integer"}, "junk"]}, "pydantic") is int
+    assert schema_type_to_python({keyword: ["junk"]}, "pydantic") is Any


### PR DESCRIPTION
### What

`schema_type_to_python` handles `enum`, `const`, `type`, arrays and objects. Everything else falls through to `return Any`. `$ref`, `anyOf`, `oneOf` and `allOf` are all unhandled, so a schema using them loses its constraints. For `$ref` that loss is not silent: it makes the converted model unusable.

Pydantic emits `$ref` for a nested model, so a round trip drops the nesting. This is not a
quiet widening of the type: the converted model is then unusable, because the regex backend
refuses a property with no `type`.

```python
to_regex(JsonSchema(json_schema_dict_to_pydantic(Person.model_json_schema(), "Person")))
ValueError: Unsupported JSON Schema structure {"title":"Address"}
```

So on `main` the converter cannot round-trip any pydantic model that contains another model.

```python
class Address(BaseModel):
    street: str
    city: str

class Person(BaseModel):
    name: str
    address: Address

json_schema_dict_to_pydantic(Person.model_json_schema(), "Person")
# before: address -> typing.Any
# after:  address -> Address(street: str, city: str)
```

The three converters also read `properties` directly off the document. Pydantic emits a *top-level* `$ref` for a self-referential model — `{"$defs": {...}, "$ref": "#/$defs/Node"}` — so `properties` is empty and the generated model has no fields at all:

```python
class Node(BaseModel):
    value: int
    children: Optional[List["Node"]] = None

json_schema_dict_to_pydantic(Node.model_json_schema(), "Node")
# before: {}   (no fields)
# after:  value: int, children: Optional[List[Any]]
```

### Why it's user-visible

Gemini is the one backend that converts a JSON schema into a Python type and ships it as `response_schema` — `models/gemini.py:181`, `JsonSchema.convert_to(output_type, ["dataclass", "typeddict", "pydantic"])`. So passing a schema with a nested object to Gemini sends a constraint that doesn't contain the nested structure, with no warning.

Other backends are unaffected: OpenAI, Ollama and LMStudio convert to `dict`, dottxt to `str`, and the local backends compile the raw schema.

### Scope

**In.** Local `$ref` (`#`, `#/$defs/…`, `#/definitions/…`), `anyOf`/`oneOf` → `Union`, and a one-element `allOf` → its subschema (the form Pydantic emits for a `$ref` with sibling metadata).

**Out.** Remote refs, dangling pointers and multi-element `allOf` stay `Any` rather than raising, so an unsupported schema still degrades instead of breaking. Merging two or more `allOf` subschemas means reconciling conflicting keywords and competing `required` sets; that's a separate change.

Reference cycles resolve to `Optional[Any]`. A recursive schema has no finite Python type
here, and the alternative is recursing until the stack ends. It is `Optional[Any]` rather
than a bare `Any` so the back edge round-trips to `{"anyOf": [{}, {"type": "null"}]}`, which
the regex backend accepts; a bare `Any` serializes to a property with no `type` and raises
the same `ValueError` as above when the recursive property is required. Null is also the
only way an instance of a required self-reference can terminate.

One incidental change: `items` given as a list (the draft-7 tuple form) previously raised `AttributeError` from `schema.get` on a list. It is now `List[Any]`. Happy to drop that if you'd rather keep the PR to the `$ref` path.

### Why this is a fix rather than a feature

`tests/types/test_json_schema_utils.py` already covers nested objects and asserts full recursion into them (`test_json_schema_dict_to_pydantic_nested_object` and the typeddict/dataclass equivalents). `$ref` is the same intent expressed through `$defs` rather than inline, so the existing tests describe behaviour that `$ref` schemas were silently not getting.

### Tests

17 added, covering local `$ref`, the draft-07 `definitions` keyword, unresolvable refs, root-level `$ref`, recursive `$ref`, `anyOf`/`oneOf`/`allOf`, the typeddict and dataclass paths, the end-to-end Pydantic round trip, and `to_regex` over
converted recursive and nested models rather than their annotations alone.

`tests/types/`: 302 passed, 2 failed. Both failures are `test_dsl.py::test_dsl_cfg_from_file` and `test_dsl_json_schema_from_file`, which fail identically on a clean checkout of `main` on Windows (`NamedTemporaryFile` cannot be reopened while held). Unrelated to this change.

ruff 0.9.1 with `--config=pyproject.toml` and mypy 1.14.1 with `--allow-redefinition` are both clean on the changed files.
