### PR TITLE
fix: include whitespace_pattern in JsonSchema equality

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -450,9 +450,15 @@ class JsonSchema(Term):
         try:
             self_dict = json.loads(self.schema)
             other_dict = json.loads(other.schema)
-            return self_dict == other_dict
+            return (
+                self_dict == other_dict
+                and self.whitespace_pattern == other.whitespace_pattern
+            )
         except json.JSONDecodeError:  # pragma: no cover
-            return self.schema == other.schema
+            return (
+                self.schema == other.schema
+                and self.whitespace_pattern == other.whitespace_pattern
+            )
 
     @classmethod
     def from_file(cls, path: str) -> "JsonSchema":

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -533,6 +533,18 @@ def test_dsl_json_schema_from_file():
         assert schema == JsonSchema(schema_content)
 
 
+def test_json_schema_equality_includes_whitespace_pattern():
+    schema = {"type": "string"}
+
+    assert JsonSchema(schema, whitespace_pattern=r"[ ]?") == JsonSchema(
+        schema, whitespace_pattern=r"[ ]?"
+    )
+    assert JsonSchema(schema, whitespace_pattern=r"[ ]?") != JsonSchema(
+        schema, whitespace_pattern=r"[\n\t ]*"
+    )
+    assert JsonSchema(schema) != JsonSchema(schema, whitespace_pattern=r"[ ]?")
+
+
 def test_dsl_python_types_to_terms():
     with pytest.raises(RecursionError):
         python_types_to_terms(None, 11)


### PR DESCRIPTION
Fixes #1981

## Summary

- Include `whitespace_pattern` in `JsonSchema` equality comparisons.
- Add regression coverage for matching, differing, and `None` patterns.

## Validation

- `uv run --frozen --with genson --with pytest pytest tests/types/test_dsl.py -q -k "not test_dsl_cfg_from_file and not test_dsl_json_schema_from_file"` ? 58 passed.
- `uv run --frozen --with pre-commit pre-commit run ruff --files src/outlines/types/dsl.py tests/types/test_dsl.py` ? passed.
- `uv run --frozen --with mypy --with urllib3 mypy --allow-redefinition src/outlines/types/dsl.py tests/types/test_dsl.py` ? no issues found.
- `git diff --check` ? passed.

The two file-based tests in the full `tests/types/test_dsl.py` run remain blocked by the repository's existing Windows `NamedTemporaryFile` permission behavior; the changed-path tests pass.
