### PR TITLE
fix(templates): don't leak stray whitespace from over-indented trailing blank lines

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -125,12 +125,22 @@ class Template:
 def build_template_from_string(
     content: str, filters: Dict[str, Callable] = {}
 ) -> jinja2.Template:
-    # Dedent, and remove extra linebreak
-    cleaned_template = inspect.cleandoc(content)
+    # Whether the original content ends on a fully blank line (i.e. two or
+    # more consecutive linebreaks), ignoring any horizontal whitespace on
+    # that line. Checked against the raw content, since `cleandoc` below
+    # would otherwise collapse this information away.
+    ends_with_linebreak = re.sub(r"[^\S\n]+", "", content).endswith("\n\n")
 
-    # Add linebreak if there were any extra linebreaks that
-    # `cleandoc` would have removed
-    ends_with_linebreak = content.replace(" ", "").endswith("\n\n")
+    # Dedent, and remove extra linebreak. `cleandoc` only fully drops a
+    # trailing whitespace-only line when its indentation doesn't exceed the
+    # common margin of the rest of the content (e.g. once tabs are expanded
+    # to spaces): an over-indented or tab-indented trailing blank line is
+    # left behind as leftover whitespace instead of being removed. Strip
+    # that leftover explicitly so it doesn't leak into the rendered
+    # template; the `ends_with_linebreak` check above restores a single
+    # trailing linebreak when the original content warrants one.
+    cleaned_template = inspect.cleandoc(content).rstrip()
+
     if ends_with_linebreak:
         cleaned_template += "\n"
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -441,3 +441,22 @@ def test_render_trailing_whitespace_preserves_linebreak():
 def test_render_trailing_whitespace_keeps_next_line_indentation():
     src = "\n    A test line \n        An indented line\n    "
     assert build_template_from_string(src).render() == "A test line \n    An indented line"
+
+
+def test_render_over_indented_trailing_blank_line_collapses_to_one_linebreak():
+    # The trailing blank line is indented past the template's common margin
+    # (4 spaces here vs. 8 trailing spaces). `cleandoc` then leaves behind
+    # leftover whitespace instead of dropping the line entirely; it must
+    # still collapse to a single trailing linebreak like the evenly
+    # indented case in `test_template_from_str_with_extra_linebreaks`.
+    src = "\n    Hello, {{ name }}!\n\n\n        "
+    assert build_template_from_string(src).render(name="World") == "Hello, World!\n"
+
+
+def test_render_tab_indented_trailing_blank_line_collapses_to_one_linebreak():
+    # Same as above, but the trailing blank line is a tab rather than
+    # over-indented spaces. `cleandoc` expands tabs before computing the
+    # dedent margin, so a lone trailing tab hits the same leftover-whitespace
+    # case even though it "looks like" less indentation than the content.
+    src = "\n    Hello, {{ name }}!\n\n\n\t"
+    assert build_template_from_string(src).render(name="World") == "Hello, World!\n"


### PR DESCRIPTION
Fixes #1985.

## What

`build_template_from_string` (used by `Template.from_string`/`Template.from_file` and by `Application`) is supposed to collapse any trailing blank line(s) in a template down to exactly one trailing linebreak. That only worked when the trailing blank line's indentation was pure spaces no deeper than the template's common margin — a more deeply indented, or tab-indented, trailing blank line leaked extra blank lines and stray whitespace straight into the rendered prompt instead.

## Root cause

- `inspect.cleandoc` only fully empties a trailing whitespace-only line when its (tab-expanded) indentation is `<=` the common margin computed from the rest of the content; otherwise it leaves a non-empty leftover line rather than dropping it.
- The existing `ends_with_linebreak` heuristic (`content.replace(" ", "").endswith("\n\n")`) only accounts for literal space characters, so it couldn't detect the blank line in the tab case either, even when `cleandoc` did clean it up.

See #1985 for the full analysis and a minimal repro.

## Fix

- `.rstrip()` `cleandoc`'s output before conditionally restoring a single trailing linebreak, so any leftover whitespace-only tail is removed regardless of why `cleandoc` left it behind.
- Broaden the "did the original content end in a blank line" check to strip all horizontal whitespace (not just `" "`), so tabs are handled the same as spaces.

Both changes are scoped to `build_template_from_string`; `Template.from_file` shares the same dedent/whitespace-collapse tail so it benefits too, but the fix lives entirely in the string path since that's where the bug is (via `cleandoc`+heuristic), not in file-specific logic.

## Tests

Added two regression tests mirroring the existing `test_template_from_str_with_extra_linebreaks` case:
- `test_render_over_indented_trailing_blank_line_collapses_to_one_linebreak`
- `test_render_tab_indented_trailing_blank_line_collapses_to_one_linebreak`

Ran locally: `tests/test_templates.py` (19/19) and `tests/test_applications.py` (6/6) pass. `ruff check` (pinned `0.9.1`, project config) and `mypy` (pinned `1.14.1`, `--allow-redefinition`) are clean on both changed files.

---

- [x] We should be able to understand what the PR does from its title only
- [x] There is a high-level description of the changes
- [x] *If I add a new feature*, there is an issue discussing it already — N/A, this is a bug fix with its own issue (#1985)
- [x] There are links to *all* the relevant issues, discussions and PRs
- [x] The branch is rebased on the latest `main` commit
- [x] **Commit messages** follow the linked guidelines
- [x] One commit per logical change
- [x] The code respects the current naming conventions
- [x] Docstrings follow the numpy style guide — N/A, no docstring changes
- [x] `pre-commit` is installed and configured on my machine, and I ran the equivalent checks (pinned `ruff`/`mypy`) before opening this PR
- [x] There are tests covering the changes
- [x] The documentation is up-to-date — N/A, no user-facing docs reference this internal helper's exact whitespace behavior

This PR was developed with the help of an AI coding assistant (Claude Code); I've read and understand every line of the diff, and ran the tests/lint/type-checks myself before opening this.