### PR TITLE
fix(mlxlm): check if output_type is None instead of truthiness

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -94,7 +94,7 @@ class MLXLMTypeAdapter(ModelTypeAdapter):
             The logits processor argument to be passed to the model.
 
         """
-        if not output_type:
+        if output_type is None:
             return None
         return [output_type]
 

--- a/tests/models/test_mlxlm_type_adapter.py
+++ b/tests/models/test_mlxlm_type_adapter.py
@@ -105,29 +105,6 @@ def test_mlxlm_type_adapter_format_input(adapter, image):
         ]))
 
 
-def test_mlxlm_type_adapter_format_output_type_falsy_processor():
-    tokenizer = MagicMock()
-    adapter = MLXLMTypeAdapter(tokenizer=tokenizer)
-
-    class FalsyProcessor:
-        def __bool__(self):
-            return False
-
-    processor = FalsyProcessor()
-    result = adapter.format_output_type(processor)
-
-    assert result == [processor]
-
-
-def test_mlxlm_type_adapter_format_output_type_none():
-    tokenizer = MagicMock()
-    adapter = MLXLMTypeAdapter(tokenizer=tokenizer)
-
-    result = adapter.format_output_type(None)
-
-    assert result is None
-
-
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
 def test_mlxlm_type_adapter_format_output_type(adapter, logits_processor):
     formatted = adapter.format_output_type(logits_processor)

--- a/tests/models/test_mlxlm_type_adapter.py
+++ b/tests/models/test_mlxlm_type_adapter.py
@@ -105,6 +105,29 @@ def test_mlxlm_type_adapter_format_input(adapter, image):
         ]))
 
 
+def test_mlxlm_type_adapter_format_output_type_falsy_processor():
+    tokenizer = MagicMock()
+    adapter = MLXLMTypeAdapter(tokenizer=tokenizer)
+
+    class FalsyProcessor:
+        def __bool__(self):
+            return False
+
+    processor = FalsyProcessor()
+    result = adapter.format_output_type(processor)
+
+    assert result == [processor]
+
+
+def test_mlxlm_type_adapter_format_output_type_none():
+    tokenizer = MagicMock()
+    adapter = MLXLMTypeAdapter(tokenizer=tokenizer)
+
+    result = adapter.format_output_type(None)
+
+    assert result is None
+
+
 @pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
 def test_mlxlm_type_adapter_format_output_type(adapter, logits_processor):
     formatted = adapter.format_output_type(logits_processor)


### PR DESCRIPTION
Fixes #1980

### Context
In \src/outlines/models/mlxlm.py\, \ormat_output_type\ previously checked \if not output_type:\. This causes issue #1980 when an \output_type\ object evaluates to \False\ in boolean context (e.g., custom processors/callables with \__bool__\ returning \False\).

### Changes
- Replaced \if not output_type:\ with \if output_type is None:\ in \MLXLMTypeAdapter.format_output_type\, matching the standard pattern across all other model adapters.
- Added unit tests in \	ests/models/test_mlxlm_type_adapter.py\ for both \None\ and falsy processor objects.