### PR TITLE
fix(applications): rebuild generator when output_type changes

### DIFF
--- a/src/outlines/applications.py
+++ b/src/outlines/applications.py
@@ -72,6 +72,7 @@ class Application:
             BlackBoxGenerator, SteerableGenerator
         ]] = None
         self.model: Optional[Model] = None
+        self._generator_output_type: Any = None
 
     def __call__(
         self,
@@ -95,12 +96,14 @@ class Application:
         """
         if model is None:
             raise ValueError("you must provide a model")
+        output_type = self.output_type
         # We save the generator to avoid creating a new one for each call.
-        # If the model has changed since the last call, we create a new
-        # generator.
-        if model != self.model:
+        # If the model or the output type has changed since the last call,
+        # we create a new generator.
+        if model != self.model or output_type != self._generator_output_type:
             self.model = model
-            self.generator = Generator(model, self.output_type)  # type: ignore
+            self._generator_output_type = output_type
+            self.generator = Generator(model, output_type)  # type: ignore
 
         prompt = self.template(**template_vars)
         assert self.generator is not None

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import MagicMock, call, patch
 
 import jinja2
 import pytest
@@ -91,3 +92,17 @@ def test_application_generator_reuse(model, another_model):
     assert application.model == another_model
     assert application.model != first_model
     assert application.generator != first_generator
+
+
+def test_application_rebuilds_generator_when_output_type_changes():
+    with patch("outlines.applications.Generator") as MockGenerator:
+        template = MagicMock()
+        application = Application(template, output_type=int)
+        model = MagicMock()
+
+        application(model, {})
+        application(model, {})
+        application.output_type = str
+        application(model, {})
+
+        assert MockGenerator.call_args_list == [call(model, int), call(model, str)]


### PR DESCRIPTION
Fixes #1982

### Context
In \Application.__call__\, the cached \Generator\ instance was only recreated when the model changed (\if model != self.model\). If an \Application\ instance had its \output_type\ updated after instantiation, subsequent calls continued to use the cached generator built with the initial \output_type\.

### Changes
- Stored \self._generator_output_type\ on \Application\ instances.
- Updated generator cache check to \if model != self.model or output_type != self._generator_output_type:\.
- Added unit test \	est_application_rebuilds_generator_when_output_type_changes\ in \	ests/test_applications.py\.