### PR TITLE
fix(caching): make cache_disabled context-local using ContextVar

### DIFF
--- a/src/outlines/caching.py
+++ b/src/outlines/caching.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import os
 import tempfile
+from contextvars import ContextVar
 from typing import Callable, Optional
 
 import cloudpickle
@@ -12,6 +13,14 @@ from diskcache import Cache, Disk
 from diskcache.core import ENOVAL, UNKNOWN, args_to_key, full_name
 
 _caching_enabled = True
+_caching_enabled_override: ContextVar[Optional[bool]] = ContextVar(
+    "outlines_caching_enabled", default=None
+)
+
+
+def _is_caching_enabled() -> bool:
+    override = _caching_enabled_override.get()
+    return _caching_enabled if override is None else override
 
 
 class CloudpickleDisk(Disk): # pragma: no cover
@@ -113,7 +122,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         if asyncio.iscoroutinefunction(cached_function):  # pragma: no cover
 
             async def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _is_caching_enabled():
                     return await cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -128,7 +137,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         else:
 
             def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _is_caching_enabled():
                     return cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -185,11 +194,8 @@ def clear_cache():
 
 @contextlib.contextmanager
 def cache_disabled():
-    # outlines.caching._caching_enabled
-    global _caching_enabled
-    original_state = _caching_enabled
-    _caching_enabled = False
+    token = _caching_enabled_override.set(False)
     try:
         yield
     finally:
-        _caching_enabled = original_state
+        _caching_enabled_override.reset(token)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,7 @@
+import asyncio
 import os
 import tempfile
+import threading
 import unittest
 from importlib import reload
 
@@ -198,6 +200,66 @@ def test_cache_disabled_decorator(test_cache):
     # scope has exited, cache is enabled again
     fn()
     assert mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_disabled_does_not_leak_to_concurrent_tasks():
+    """Ensure cache_disabled does not affect tasks that did not enter it"""
+
+    from outlines.caching import _is_caching_enabled, cache_disabled
+
+    disabled = asyncio.Event()
+    observed = asyncio.Event()
+    states = {}
+
+    async def with_cache_disabled():
+        with cache_disabled():
+            disabled.set()
+            await observed.wait()
+            states["inside"] = _is_caching_enabled()
+
+    async def concurrent():
+        await disabled.wait()
+        states["outside"] = _is_caching_enabled()
+        observed.set()
+
+    await asyncio.gather(with_cache_disabled(), concurrent())
+
+    assert states["inside"] is False
+    assert states["outside"] is True
+
+
+@pytest.mark.asyncio
+async def test_cache_disabled_restores_state_across_await():
+    """Ensure cache_disabled restores the previous state when the block awaits"""
+
+    from outlines.caching import _is_caching_enabled, cache_disabled
+
+    with cache_disabled():
+        await asyncio.sleep(0)
+        assert _is_caching_enabled() is False
+
+    assert _is_caching_enabled() is True
+
+
+def test_disable_cache_applies_to_other_threads():
+    """Ensure disable_cache remains a process-wide switch"""
+
+    import outlines.caching
+
+    states = []
+    original_state = outlines.caching._caching_enabled
+    try:
+        outlines.caching.disable_cache()
+        thread = threading.Thread(
+            target=lambda: states.append(outlines.caching._is_caching_enabled())
+        )
+        thread.start()
+        thread.join()
+    finally:
+        outlines.caching._caching_enabled = original_state
+
+    assert states == [False]
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #1983

### Context
\ cache_disabled()\ directly mutated the global \_caching_enabled\ boolean. In asynchronous environments, calling \with cache_disabled():\ in one task inadvertently disabled caching globally for concurrent tasks running in the same process loop.

### Changes
- Added a \ContextVar[Optional[bool]]\ (\_caching_enabled_override\) defaulting to \None\.
- Implemented \_is_caching_enabled()\ to check the context-local override first, falling back to global \_caching_enabled\ if \None\.
- Updated \cache_disabled()\ context manager to set and reset the \ContextVar\ token.
- Retained global \_caching_enabled\ so process-level switches like \disable_cache()\ continue to apply across worker threads.
- Added unit tests in \	ests/test_cache.py\ covering async task isolation and thread behavior.