### PR TITLE
fix(applications): make output_type, model and generator private

### DIFF
--- a/src/outlines/applications.py
+++ b/src/outlines/applications.py
@@ -67,11 +67,11 @@ class Application:
 
         """
         self.template = template
-        self.output_type = output_type
-        self.generator: Optional[Union[
+        self._output_type = output_type
+        self._generator: Optional[Union[
             BlackBoxGenerator, SteerableGenerator
         ]] = None
-        self.model: Optional[Model] = None
+        self._model: Optional[Model] = None
 
     def __call__(
         self,
@@ -98,10 +98,10 @@ class Application:
         # We save the generator to avoid creating a new one for each call.
         # If the model has changed since the last call, we create a new
         # generator.
-        if model != self.model:
-            self.model = model
-            self.generator = Generator(model, self.output_type)  # type: ignore
+        if model != self._model:
+            self._model = model
+            self._generator = Generator(model, self._output_type)  # type: ignore
 
         prompt = self.template(**template_vars)
-        assert self.generator is not None
-        return self.generator(prompt, **inference_kwargs)
+        assert self._generator is not None
+        return self._generator(prompt, **inference_kwargs)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -31,9 +31,9 @@ def test_application_initialization():
     application = Application(template, output_type)
 
     assert application.template == template
-    assert application.output_type == output_type
-    assert application.model is None
-    assert application.generator is None
+    assert application._output_type == output_type
+    assert application._model is None
+    assert application._generator is None
 
 
 def test_application_generator_no_model():
@@ -80,14 +80,14 @@ def test_application_generator_reuse(model, another_model):
     application = Application(template, output_type)
 
     application(model, {"value": "example"}, max_new_tokens=10)
-    first_generator = application.generator
-    first_model = application.model
+    first_generator = application._generator
+    first_model = application._model
 
     application(model, {"value": "example"}, max_new_tokens=10)
-    assert application.model == first_model
-    assert application.generator == first_generator
+    assert application._model == first_model
+    assert application._generator == first_generator
 
     application(another_model, {"value": "example"}, max_new_tokens=10)
-    assert application.model == another_model
-    assert application.model != first_model
-    assert application.generator != first_generator
+    assert application._model == another_model
+    assert application._model != first_model
+    assert application._generator != first_generator


### PR DESCRIPTION
Closes #1982

## What

Makes , , and  private attributes (prefixed with ) on the  class.

## Why

As suggested by @RobinPicard in #1982: rather than adding defensive cache-invalidation logic to detect when  changes after construction, making the attribute private removes the invalid state entirely — users can no longer mutate it after construction, so the stale-generator scenario cannot occur.

 and  are made private too since they are internal caching state, not part of the public API.

## Changes

- : rename  → ,  → ,  → 
- : update assertions to use the private attribute names