### PR TITLE
fix(anthropic): pass leading system prompts via the system parameter

### DIFF
--- a/src/outlines/models/anthropic.py
+++ b/src/outlines/models/anthropic.py
@@ -28,7 +28,7 @@ class AnthropicTypeAdapter(ModelTypeAdapter):
 
     @singledispatchmethod
     def format_input(self, model_input):
-        """Generate the `messages` argument to pass to the client.
+        """Generate the input arguments to pass to the client.
 
         Parameters
         ----------
@@ -38,7 +38,7 @@ class AnthropicTypeAdapter(ModelTypeAdapter):
         Returns
         -------
         dict
-            The `messages` argument to pass to the client.
+            The input arguments to pass to the client.
 
         """
         raise TypeError(
@@ -63,16 +63,30 @@ class AnthropicTypeAdapter(ModelTypeAdapter):
 
     @format_input.register(Chat)
     def format_chat_model_input(self, model_input: Chat) -> dict:
-        """Generate the `messages` argument to pass to the client when the user
+        """Generate the input arguments to pass to the client when the user
         passes a Chat instance.
 
         """
-        return {
+        system_prompts = []
+        first_message_index = 0
+
+        for message in model_input.messages:
+            if message["role"] != "system":
+                break
+            system_prompts.append(message["content"])
+            first_message_index += 1
+
+        formatted_input: dict[str, Any] = {
             "messages": [
                 self._create_message(message["role"], message["content"])
-                for message in model_input.messages
+                for message in model_input.messages[first_message_index:]
             ]
         }
+
+        if system_prompts:
+            formatted_input["system"] = "\n".join(system_prompts)
+
+        return formatted_input
 
     def _create_message(self, role: str, content: str | list) -> dict:
         """Create a message."""

--- a/tests/models/test_anthopic_type_adapter.py
+++ b/tests/models/test_anthopic_type_adapter.py
@@ -69,8 +69,8 @@ def test_anthropic_type_adapter_input_chat(adapter, image):
     ])
     result = adapter.format_input(model_input)
     assert result == {
+        "system": "prompt",
         "messages": [
-            {"role": "system", "content": "prompt"},
             {"role": "user", "content": [
                 {
                     "type": "image",
@@ -84,6 +84,27 @@ def test_anthropic_type_adapter_input_chat(adapter, image):
             ]},
             {"role": "assistant", "content": "response"},
         ]
+    }
+
+
+def test_anthropic_type_adapter_preserves_mid_conversation_system_messages(adapter):
+    model_input = Chat(messages=[
+        {"role": "system", "content": "global instruction"},
+        {"role": "system", "content": "additional context"},
+        {"role": "user", "content": "hello"},
+        {"role": "system", "content": "new instruction"},
+        {"role": "assistant", "content": "response"},
+    ])
+
+    result = adapter.format_input(model_input)
+
+    assert result == {
+        "system": "global instruction\nadditional context",
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "new instruction"},
+            {"role": "assistant", "content": "response"},
+        ],
     }
 
 


### PR DESCRIPTION
## Summary

Anthropic expects conversation-start system instructions in the top-level `system` parameter, not as a `system` role inside `messages`. The current adapter serializes every `Chat` item into `messages`, so a common `Chat([system, user])` input produces an invalid standard Messages API request.

This change:

- moves consecutive leading system prompts into the top-level `system` parameter;
- joins multiple leading system prompts in order;
- preserves mid-conversation system turns in `messages`, so their placement semantics are not changed;
- updates the Anthropic adapter tests for both the common leading-system case and mixed leading/mid-conversation system messages.

The behavior matches the [Anthropic Messages API](https://platform.claude.com/docs/en/api/messages/create). Historical context: #1587 introduced the need for system prompts in remote model chat inputs; `Chat` support now exists, and this fixes the Anthropic-specific serialization path.

## Validation

- Red baseline: 2 adapter assertions failed before the implementation, then passed after the change.
- Python 3.10: 11 Anthropic tests passed (5 API tests deselected).
- Python 3.12: 11 Anthropic tests passed (5 API tests deselected).
- Python 3.13: 11 Anthropic tests passed (5 API tests deselected).
- Anthropic SDK request probe with `httpx.MockTransport`: confirmed `system` is top-level and the leading system turn is absent from `messages`.
- `mypy` on both changed files: passed.
- `ruff` and all non-mypy pre-commit hooks across the repository: passed. The clean local pre-commit mypy environment lacks the existing `urllib3` dependency used by `src/outlines/exceptions.py`; running mypy in the synced project environment passes the changed files.
- Full non-API suite: 1057 passed, 19 skipped, 75 deselected. The remaining 17 local failures are environment-specific: 14 require the Ollama daemon/models installed by CI, and 3 are current Apple Silicon MLX tokenizer/dependency incompatibilities. No Anthropic test failed.

## Checklist

- [x] The title describes the change.
- [x] The change is a focused bug fix, not a new feature.
- [x] The branch is based on the latest `main`.
- [x] There is one logical commit with a guideline-compliant message.
- [x] Naming and NumPy-style docstrings remain consistent.
- [x] Pre-commit was run and the local environment limitation is documented above.
- [x] Regression tests cover the changed behavior.
- [x] User-facing documentation is unaffected; adapter docstrings were updated for the new return shape.
