### PR TITLE
fix(models): raise GenerationError for streamed refusals

### DIFF
--- a/src/outlines/models/openai.py
+++ b/src/outlines/models/openai.py
@@ -335,8 +335,16 @@ class OpenAI(Model):
                 **inference_kwargs
             )
             for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"OpenAI refused to answer the request: {refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
 
 class AsyncOpenAI(AsyncModel):
@@ -465,8 +473,16 @@ class AsyncOpenAI(AsyncModel):
                 **inference_kwargs
             )
             async for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"OpenAI refused to answer the request: {refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
 
 def from_openai(

--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -198,8 +198,17 @@ class SGLang(Model):
                 **client_args, stream=True,
             )
             for chunk in stream:  # pragma: no cover
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"The SGLang server refused to answer the request: "
+                            f"{refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
     def _build_client_args(
         self,
@@ -349,8 +358,17 @@ class AsyncSGLang(AsyncModel):
                 stream=True,
             )
             async for chunk in stream:  # pragma: no cover
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"The SGLang server refused to answer the request: "
+                            f"{refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
     def _build_client_args(
         self,

--- a/src/outlines/models/vllm.py
+++ b/src/outlines/models/vllm.py
@@ -187,8 +187,17 @@ class VLLM(Model):
                 **client_args, stream=True,
             )
             for chunk in stream:  # pragma: no cover
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"The vLLM server refused to answer the request: "
+                            f"{refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
     def _build_client_args(
         self,
@@ -332,8 +341,17 @@ class AsyncVLLM(AsyncModel):
                 stream=True,
             )
             async for chunk in stream:  # pragma: no cover
-                if chunk.choices and chunk.choices[0].delta.content is not None:
-                    yield chunk.choices[0].delta.content
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    refusal = getattr(delta, "refusal", None)
+                    if refusal is not None:
+                        raise GenerationError(
+                            f"The vLLM server refused to answer the request: "
+                            f"{refusal}",
+                            provider=PROVIDER,
+                        )
+                    if delta.content is not None:
+                        yield delta.content
 
     def _build_client_args(
         self,

--- a/tests/models/test_provider_exceptions.py
+++ b/tests/models/test_provider_exceptions.py
@@ -153,6 +153,38 @@ def _refusal_response():
     )
 
 
+def _stream_chunk(*deltas):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta) for delta in deltas]
+    )
+
+
+def _streamed_refusal_chunks():
+    return [
+        _stream_chunk(
+            SimpleNamespace(
+                content="must-not-yield",
+                refusal="safety refusal",
+            )
+        )
+    ]
+
+
+def _streamed_non_refusal_chunks():
+    return [
+        _stream_chunk(),
+        _stream_chunk(
+            SimpleNamespace(content="first"),
+            SimpleNamespace(content="ignored", refusal="safety refusal"),
+        ),
+    ]
+
+
+async def _async_items(items):
+    for item in items:
+        yield item
+
+
 class DottxtSchema(BaseModel):
     value: str
 
@@ -195,8 +227,28 @@ SYNC_STREAM_CASES    = [p.sync_stream_case()     for p in PROVIDERS if p.model_s
 ASYNC_GENERATE_CASES = [p.async_generate_case()  for p in PROVIDERS if p.model_async]
 ASYNC_STREAM_CASES   = [p.async_stream_case()    for p in PROVIDERS if p.model_async and p.has_stream]
 
-SYNC_REFUSAL_CASES  = [pytest.param(p.model_sync,  p.name, id=p.name) for p in PROVIDERS if p.has_refusal and p.model_sync]
-ASYNC_REFUSAL_CASES = [pytest.param(p.model_async, p.name, id=p.name) for p in PROVIDERS if p.has_refusal and p.model_async]
+REFUSAL_MESSAGES = {
+    "openai": "OpenAI refused to answer the request: safety refusal",
+    "vllm": "The vLLM server refused to answer the request: safety refusal",
+    "sglang": "The SGLang server refused to answer the request: safety refusal",
+}
+
+SYNC_REFUSAL_CASES = [
+    pytest.param(p.model_sync, p.name, REFUSAL_MESSAGES[p.name], id=p.name)
+    for p in PROVIDERS if p.has_refusal and p.model_sync
+]
+ASYNC_REFUSAL_CASES = [
+    pytest.param(p.model_async, p.name, REFUSAL_MESSAGES[p.name], id=p.name)
+    for p in PROVIDERS if p.has_refusal and p.model_async
+]
+SYNC_REFUSAL_MODEL_CASES = [
+    pytest.param(p.model_sync, id=p.name)
+    for p in PROVIDERS if p.has_refusal and p.model_sync
+]
+ASYNC_REFUSAL_MODEL_CASES = [
+    pytest.param(p.model_async, id=p.name)
+    for p in PROVIDERS if p.has_refusal and p.model_async
+]
 
 
 @pytest.mark.parametrize("case", SYNC_GENERATE_CASES)
@@ -303,27 +355,97 @@ async def test_pass_through_non_provider_errors_stream_async(case):
     assert exc_info.value is original
 
 
-@pytest.mark.parametrize("model_cls, provider", SYNC_REFUSAL_CASES)
-def test_refusal_raises_generation_error_sync(model_cls, provider):
+@pytest.mark.parametrize(
+    "model_cls, provider, expected_message", SYNC_REFUSAL_CASES
+)
+def test_refusal_raises_generation_error_sync(
+    model_cls, provider, expected_message
+):
     client = _chat_completions(Mock(return_value=_refusal_response()))
     model = model_cls(client)
 
-    with pytest.raises(GenerationError, match="refused to answer the request") as exc_info:
+    with pytest.raises(GenerationError) as exc_info:
         model.generate("hello")
 
     assert exc_info.value.provider == provider
+    assert str(exc_info.value) == expected_message
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model_cls, provider", ASYNC_REFUSAL_CASES)
-async def test_refusal_raises_generation_error_async(model_cls, provider):
+@pytest.mark.parametrize(
+    "model_cls, provider, expected_message", ASYNC_REFUSAL_CASES
+)
+async def test_refusal_raises_generation_error_async(
+    model_cls, provider, expected_message
+):
     client = _chat_completions(AsyncMock(return_value=_refusal_response()))
     model = model_cls(client)
 
-    with pytest.raises(GenerationError, match="refused to answer the request") as exc_info:
+    with pytest.raises(GenerationError) as exc_info:
         await model.generate("hello")
 
     assert exc_info.value.provider == provider
+    assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.parametrize(
+    "model_cls, provider, expected_message", SYNC_REFUSAL_CASES
+)
+def test_streamed_refusal_raises_generation_error_sync(
+    model_cls, provider, expected_message
+):
+    client = _chat_completions(
+        Mock(return_value=iter(_streamed_refusal_chunks()))
+    )
+    model = model_cls(client)
+
+    with pytest.raises(GenerationError) as exc_info:
+        next(model.stream("hello"))
+
+    assert exc_info.value.provider == provider
+    assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_cls, provider, expected_message", ASYNC_REFUSAL_CASES
+)
+async def test_streamed_refusal_raises_generation_error_async(
+    model_cls, provider, expected_message
+):
+    client = _chat_completions(
+        AsyncMock(return_value=_async_items(_streamed_refusal_chunks()))
+    )
+    model = model_cls(client)
+
+    with pytest.raises(GenerationError) as exc_info:
+        await _anext(model.stream("hello"))
+
+    assert exc_info.value.provider == provider
+    assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.parametrize("model_cls", SYNC_REFUSAL_MODEL_CASES)
+def test_streamed_non_refusal_deltas_sync(model_cls):
+    client = _chat_completions(
+        Mock(return_value=iter(_streamed_non_refusal_chunks()))
+    )
+    model = model_cls(client)
+
+    assert list(model.stream("hello")) == ["first"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_cls", ASYNC_REFUSAL_MODEL_CASES)
+async def test_streamed_non_refusal_deltas_async(model_cls):
+    client = _chat_completions(
+        AsyncMock(return_value=_async_items(_streamed_non_refusal_chunks()))
+    )
+    model = model_cls(client)
+
+    result = [chunk async for chunk in model.stream("hello")]
+
+    assert result == ["first"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils/mock_openai_client.py
+++ b/tests/test_utils/mock_openai_client.py
@@ -31,6 +31,7 @@ class MockStreamingChunk:
             choice = MagicMock()
             delta = MagicMock()
             delta.content = content
+            delta.refusal = None
             choice.delta = delta
             self.choices = [choice]
 


### PR DESCRIPTION
## Summary

The sync and async stream paths for OpenAI, vLLM, and SGLang only looked at `delta.content`. If a provider returned a refusal together with content, Outlines yielded the content instead of raising the `GenerationError` used by non-streamed calls.

This checks the refusal before yielding content in all six paths. It uses `getattr` because older OpenAI SDK versions do not define the refusal field, and it leaves the existing first-choice behavior unchanged.

The tests cover refusal chunks that also contain content, empty choices, missing refusal attributes, and refusals in later choices.

## Tests

- `uv run pytest -q tests/models/test_provider_exceptions.py -k refusal` — 18 passed, 62 deselected
- `uv run pytest -q tests/models/test_openai.py tests/models/test_vllm.py tests/models/test_sglang.py -m 'not api_call'` — 54 passed, 19 deselected
- `uv run pytest -q tests/models/test_provider_exceptions.py` — 80 passed
- Mypy over the five changed files — passed
- Ruff and `git diff --check` — passed
