### PR TITLE
fix: make to_regex grouping non-capturing so backreferences survive

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -991,36 +991,38 @@ def to_regex(term: Term) -> str:
         The regular expression as a string.
 
     """
+    # Groups bind operators, they never capture: a capturing wrapper renumbers
+    # the groups inside it and breaks numbered backreferences in user patterns.
     if isinstance(term, String):
         return re.escape(term.value)
     elif isinstance(term, Regex):
-        return f"({term.pattern})"
+        return f"(?:{term.pattern})"
     elif isinstance(term, JsonSchema):
         regex_str = build_regex_from_schema(term.schema, term.whitespace_pattern)
-        return f"({regex_str})"
+        return f"(?:{regex_str})"
     elif isinstance(term, Choice):
         regexes = [to_regex(python_types_to_terms(item)) for item in term.items]
-        return f"({'|'.join(regexes)})"
+        return f"(?:{'|'.join(regexes)})"
     elif isinstance(term, KleeneStar):
-        return f"({to_regex(term.term)})*"
+        return f"(?:{to_regex(term.term)})*"
     elif isinstance(term, KleenePlus):
-        return f"({to_regex(term.term)})+"
+        return f"(?:{to_regex(term.term)})+"
     elif isinstance(term, Optional):
-        return f"({to_regex(term.term)})?"
+        return f"(?:{to_regex(term.term)})?"
     elif isinstance(term, Alternatives):
         regexes = [to_regex(subterm) for subterm in term.terms]
-        return f"({'|'.join(regexes)})"
+        return f"(?:{'|'.join(regexes)})"
     elif isinstance(term, Sequence):
         regexes = [to_regex(subterm) for subterm in term.terms]
         return f"{''.join(regexes)}"
     elif isinstance(term, QuantifyExact):
-        return f"({to_regex(term.term)}){{{term.count}}}"
+        return f"(?:{to_regex(term.term)}){{{term.count}}}"
     elif isinstance(term, QuantifyMinimum):
-        return f"({to_regex(term.term)}){{{term.min_count},}}"
+        return f"(?:{to_regex(term.term)}){{{term.min_count},}}"
     elif isinstance(term, QuantifyMaximum):
-        return f"({to_regex(term.term)}){{0,{term.max_count}}}"
+        return f"(?:{to_regex(term.term)}){{0,{term.max_count}}}"
     elif isinstance(term, QuantifyBetween):
-        return f"({to_regex(term.term)}){{{term.min_count},{term.max_count}}}"
+        return f"(?:{to_regex(term.term)}){{{term.min_count},{term.max_count}}}"
     else:
         raise TypeError(
             f"Cannot convert object {repr(term)} to a regular expression."

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -37,7 +37,7 @@ mock_responses = [
             ],
             'model': MODEL_NAME,
             'max_tokens': 10,
-            'extra_body': {'structured_outputs': {'regex': '("[^"]*")'}},
+            'extra_body': {'structured_outputs': {'regex': '(?:"[^"]*")'}},
         },
         "Mock response"
     ),
@@ -48,7 +48,7 @@ mock_responses = [
             ],
             'model': MODEL_NAME,
             'max_tokens': 10,
-            'extra_body': {'structured_outputs': {'regex': '("[^"]*")'}},
+            'extra_body': {'structured_outputs': {'regex': '(?:"[^"]*")'}},
             'stream': True,
         },
         ["Mock", "response"]

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -383,7 +383,7 @@ def test_dsl_term_pydantic_combination():
     schema = Model.model_json_schema()
     assert schema == {
         "properties": {
-            "field": {"pattern": "(ab|c)", "title": "Field", "type": "string"}
+            "field": {"pattern": "(?:ab|c)", "title": "Field", "type": "string"}
         },
         "required": ["field"],
         "title": "Model",
@@ -719,7 +719,7 @@ def test_dsl_literal_bool():
 def test_dsl_numeric_literal_escapes_regex_metacharacters():
     # A float's ``.`` must match literally, not act as a regex wildcard.
     term = python_types_to_terms(1.5)
-    assert to_regex(term) == r"(1\.5)"
+    assert to_regex(term) == r"(?:1\.5)"
     assert term.matches("1.5") is True
     assert term.matches("1x5") is False
 
@@ -1223,40 +1223,61 @@ def test_to_regex():
     assert to_regex(string_term) == r"hello"
 
     regex_term = Regex("[0-9]+")
-    assert to_regex(regex_term) == r"([0-9]+)"
+    assert to_regex(regex_term) == r"(?:[0-9]+)"
 
     json_schema_term = JsonSchema({"type": "integer"})
-    assert to_regex(json_schema_term) == r"((-)?(0|[1-9][0-9]*))"
+    assert to_regex(json_schema_term) == r"(?:(-)?(0|[1-9][0-9]*))"
 
     choice_term = Choice(["a", "b", "c"])
-    assert to_regex(choice_term) == r"(a|b|c)"
+    assert to_regex(choice_term) == r"(?:a|b|c)"
 
     kleene_star = KleeneStar(String("a"))
-    assert to_regex(kleene_star) == r"(a)*"
+    assert to_regex(kleene_star) == r"(?:a)*"
 
     kleene_plus = KleenePlus(String("a"))
-    assert to_regex(kleene_plus) == r"(a)+"
+    assert to_regex(kleene_plus) == r"(?:a)+"
 
     optional_term = Optional(String("a"))
-    assert to_regex(optional_term) == r"(a)?"
+    assert to_regex(optional_term) == r"(?:a)?"
 
     alt_term = Alternatives([String("a"), String("b")])
-    assert to_regex(alt_term) == r"(a|b)"
+    assert to_regex(alt_term) == r"(?:a|b)"
 
     seq_term = Sequence([String("a"), String("b")])
     assert to_regex(seq_term) == r"ab"
 
     exact_term = QuantifyExact(String("a"), 3)
-    assert to_regex(exact_term) == r"(a){3}"
+    assert to_regex(exact_term) == r"(?:a){3}"
 
     min_term = QuantifyMinimum(String("a"), 2)
-    assert to_regex(min_term) == r"(a){2,}"
+    assert to_regex(min_term) == r"(?:a){2,}"
 
     max_term = QuantifyMaximum(String("a"), 5)
-    assert to_regex(max_term) == r"(a){0,5}"
+    assert to_regex(max_term) == r"(?:a){0,5}"
 
     between_term = QuantifyBetween(String("a"), 1, 3)
-    assert to_regex(between_term) == r"(a){1,3}"
+    assert to_regex(between_term) == r"(?:a){1,3}"
 
     with pytest.raises(TypeError):
         to_regex(Term())
+
+
+def test_to_regex_groups_are_non_capturing():
+    """A capturing wrapper would renumber the groups inside a user's pattern,
+    breaking numbered backreferences."""
+    for pattern, value in [
+        (r"(a)\1", "aa"),
+        (r"(ab)+\1", "ababab"),
+        (r"([xy])z\1", "xzx"),
+        (r"(a)(b)\2\1", "abba"),
+    ]:
+        term = Regex(pattern)
+        assert term.matches(value) == (_re.fullmatch(pattern, value) is not None)
+
+    nested = KleeneStar(Regex(r"(a)\1"))
+    assert nested.matches("aa")
+    assert nested.matches("aaaa")
+    assert not nested.matches("ab")
+
+    # Named backreferences are unaffected by renumbering and must keep working.
+    assert Regex(r"(?P<c>a)(?P=c)").matches("aa")

--- a/tests/types/test_to_regex.py
+++ b/tests/types/test_to_regex.py
@@ -26,59 +26,59 @@ def test_to_regex_simple():
     assert a.matches("a") is True
 
     a = Regex("[0-9]")
-    assert to_regex(a) == "([0-9])"
+    assert to_regex(a) == "(?:[0-9])"
     assert a.matches(0) is True
     assert a.matches(10) is False
     assert a.matches("a") is False
 
     a = JsonSchema({"type": "integer"})
-    assert to_regex(a) == r"((-)?(0|[1-9][0-9]*))"
+    assert to_regex(a) == r"(?:(-)?(0|[1-9][0-9]*))"
     assert a.matches(1) is True
     assert a.matches("1") is True
     assert a.matches("a") is False
 
     a = Choice(["a", "b"])
-    assert to_regex(a) == "(a|b)"
+    assert to_regex(a) == "(?:a|b)"
     assert a.matches("a") is True
     assert a.matches("b") is True
     assert a.matches("c") is False
 
     a = Optional(String("a"))
-    assert to_regex(a) == "(a)?"
+    assert to_regex(a) == "(?:a)?"
     assert a.matches("") is True
     assert a.matches("a") is True
 
     a = KleeneStar(String("a"))
-    assert to_regex(a) == "(a)*"
+    assert to_regex(a) == "(?:a)*"
     assert a.matches("") is True
     assert a.matches("a") is True
     assert a.matches("aaaaa") is True
 
     a = KleenePlus(String("a"))
-    assert to_regex(a) == "(a)+"
+    assert to_regex(a) == "(?:a)+"
     assert a.matches("") is False
     assert a.matches("a") is True
     assert a.matches("aaaaa") is True
 
     a = QuantifyExact(String("a"), 2)
-    assert to_regex(a) == "(a){2}"
+    assert to_regex(a) == "(?:a){2}"
     assert a.matches("a") is False
     assert a.matches("aa") is True
     assert a.matches("aaa") is False
 
     a = QuantifyMinimum(String("a"), 2)
-    assert to_regex(a) == "(a){2,}"
+    assert to_regex(a) == "(?:a){2,}"
     assert a.matches("a") is False
     assert a.matches("aa") is True
     assert a.matches("aaa") is True
 
     a = QuantifyMaximum(String("a"), 2)
-    assert to_regex(a) == "(a){0,2}"
+    assert to_regex(a) == "(?:a){0,2}"
     assert a.matches("aa") is True
     assert a.matches("aaa") is False
 
     a = QuantifyBetween(String("a"), 1, 2)
-    assert to_regex(a) == "(a){1,2}"
+    assert to_regex(a) == "(?:a){1,2}"
     assert a.matches("") is False
     assert a.matches("a") is True
     assert a.matches("aa") is True
@@ -90,4 +90,4 @@ def test_to_regex_simple():
 
 def test_to_regex_combinations():
     a = Sequence([Regex("dog|cat"), String("fish")])
-    assert to_regex(a) == "(dog|cat)fish"
+    assert to_regex(a) == "(?:dog|cat)fish"


### PR DESCRIPTION
fix: make `to_regex` grouping non-capturing so backreferences survive

`to_regex` wraps terms in capturing groups. The groups are there to bind operators, but
capturing renumbers every group inside them — so a user pattern carrying a numbered
backreference is rewritten to mean something else, and in the common case fails to compile.

```python
import re
from outlines.types import Regex

re.fullmatch(r"(a)\1", "aa")      # matches
Regex(r"(a)\1").matches("aa")     # re.PatternError: cannot refer to an open group
```

`Regex(r"(a)\1")` emits `((a)\1)`. What the user wrote as group 1 is now group 2, and `\1`
refers to the wrapper, which is still open at that position.

Every numbered backreference is affected:

| pattern | `re.fullmatch` | `Regex(...).matches` |
|---|---|---|
| `(a)\1` on `"aa"` | True | **PatternError** |
| `(ab)+\1` on `"ababab"` | True | **PatternError** |
| `([xy])z\1` on `"xzx"` | True | **PatternError** |
| `(a)(b)\2\1` on `"abba"` | True | **PatternError** |

Named backreferences are unaffected — `(?P<c>a)(?P=c)` works, because names are not renumbered.
The pattern's behaviour depends on which group syntax the user happened to pick.

## The change

Every grouping wrapper in `to_regex` becomes `(?:...)`. Nothing reads these groups back — the
regex is only ever `fullmatch`ed or compiled to an automaton by a backend — so capturing buys
nothing. It also lifts a quieter limit: nested terms currently emit one capture group per level,
and Python's `re` caps a pattern at 100 groups.

`String` (an escaped literal) and `Sequence` (bare concatenation) emitted no wrapper and are
unchanged.

## Why not just the `Regex` branch

Every combinator wraps too, so the renumbering compounds. Fixing only `Regex` leaves this
broken, one level down:

```python
KleeneStar(Regex(r"(a)\1"))   # still an open-group reference
```

## Test churn

24 assertions and 2 mock keys encoded the old wrapper, so they move with it:

- `tests/types/test_dsl.py` — 13 expected values
- `tests/types/test_to_regex.py` — 11 expected values
- `tests/test_generator.py` — 2 mock request keys

The last one is worth flagging: `mock_openai_client` looks up canned responses by the exact
request payload, and the payload embeds the emitted regex. A stale key fails as
`ValueError: No response found`, which reads like a logic break but is a fixture.

## Tests

Added `test_to_regex_groups_are_non_capturing`: four backreferenced patterns checked against
`re.fullmatch` as the oracle, one nested under `KleeneStar`, and a named backreference to pin
that path. It fails on `main` with `re.PatternError` and passes here.

`pytest tests/types tests/test_generator.py` → **364 passed, 3 failed**. All three fail
identically on unmodified `main`: `test_dsl_cfg_from_file` and `test_dsl_json_schema_from_file`
raise `PermissionError` reopening a `NamedTemporaryFile` on Windows, and
`test_steerable_generator_init_cfg_output_type` is already red. `ruff check --config=pyproject.toml`
passes on all four files.

---

**AI-assisted contribution.** Per CONTRIBUTING.md: I used AI assistance to probe the behaviour
and draft this description. I verified the failure and the fix myself against `re.fullmatch` as
an independent oracle, and I can explain every line of the change.
