### PR TITLE
fix(models): validate multimodal text prompts consistently

### DIFF
--- a/src/outlines/models/anthropic.py
+++ b/src/outlines/models/anthropic.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 from outlines.exceptions import normalize_provider_errors
 from outlines.inputs import Chat, Image
 from outlines.models.base import Model, ModelTypeAdapter
+from outlines.models.utils import split_multimodal_input
 
 if TYPE_CHECKING:
     from anthropic import Anthropic as AnthropicClient
@@ -84,8 +85,7 @@ class AnthropicTypeAdapter(ModelTypeAdapter):
             }
 
         elif isinstance(content, list):
-            prompt = content[0]
-            images = content[1:]
+            prompt, images = split_multimodal_input(content)
 
             if not all(isinstance(image, Image) for image in images):
                 raise ValueError("All assets provided must be of type Image")

--- a/src/outlines/models/gemini.py
+++ b/src/outlines/models/gemini.py
@@ -13,6 +13,7 @@ from typing import (
 from outlines.exceptions import normalize_provider_errors
 from outlines.inputs import Image, Chat
 from outlines.models.base import Model, ModelTypeAdapter
+from outlines.models.utils import split_multimodal_input
 from outlines.types import CFG, Choice, JsonSchema, Regex
 from outlines.types.utils import (
     is_enum,
@@ -116,8 +117,7 @@ class GeminiTypeAdapter(ModelTypeAdapter):
             }
 
         elif isinstance(content, list):
-            prompt = content[0]
-            images = content[1:]
+            prompt, images = split_multimodal_input(content)
 
             if not all(isinstance(image, Image) for image in images):
                 raise ValueError("All assets provided must be of type Image")

--- a/src/outlines/models/lmstudio.py
+++ b/src/outlines/models/lmstudio.py
@@ -17,6 +17,7 @@ from typing import (
 
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
+from outlines.models.utils import split_multimodal_input
 from outlines.types import CFG, JsonSchema, Regex
 
 if TYPE_CHECKING:
@@ -71,8 +72,7 @@ class LMStudioTypeAdapter(ModelTypeAdapter):
         """Handle list input containing prompt and images."""
         from lmstudio import Chat as LMSChat
 
-        prompt = model_input[0]
-        images = model_input[1:]
+        prompt, images = split_multimodal_input(model_input)
 
         if not all(isinstance(img, Image) for img in images):
             raise ValueError("All assets provided must be of type Image")
@@ -104,8 +104,7 @@ class LMStudioTypeAdapter(ModelTypeAdapter):
                 if isinstance(content, str):
                     chat.add_user_message(content)
                 elif isinstance(content, list):
-                    prompt = content[0]
-                    images = content[1:]
+                    prompt, images = split_multimodal_input(content)
                     if not all(isinstance(img, Image) for img in images):
                         raise ValueError("All assets provided must be of type Image")
                     image_handles = [self._prepare_lmstudio_image(img) for img in images]

--- a/src/outlines/models/mistral.py
+++ b/src/outlines/models/mistral.py
@@ -17,7 +17,10 @@ from pydantic import TypeAdapter
 from outlines.exceptions import normalize_provider_errors
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
-from outlines.models.utils import set_additional_properties_false_json_schema
+from outlines.models.utils import (
+    set_additional_properties_false_json_schema,
+    split_multimodal_input,
+)
 from outlines.types import JsonSchema, Regex, CFG
 from outlines.types.utils import (
     is_dataclass,
@@ -158,18 +161,13 @@ class MistralTypeAdapter(ModelTypeAdapter):
         if isinstance(content, str):
             return content
         elif isinstance(content, list):
-            if not content:
-                raise ValueError("Content list cannot be empty.")
-            if not isinstance(content[0], str):
-                raise ValueError(
-                    "The first item in the list should be a string."
-                )
-            if len(content) == 1:
-                return content[0]
+            prompt, assets = split_multimodal_input(content)
+            if not assets:
+                return prompt
             content_parts: List[Dict[str, Union[str, Dict[str, str]]]] = [
-                {"type": "text", "text": content[0]}
+                {"type": "text", "text": prompt}
             ]
-            for item in content[1:]:
+            for item in assets:
                 if isinstance(item, Image):
                     data_url = f"data:{item.image_format};base64,{item.image_str}"
                     content_parts.append({

--- a/src/outlines/models/ollama.py
+++ b/src/outlines/models/ollama.py
@@ -14,6 +14,7 @@ from typing import (
 from outlines.exceptions import normalize_provider_errors
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
+from outlines.models.utils import split_multimodal_input
 from outlines.types import CFG, JsonSchema, Regex
 
 if TYPE_CHECKING:
@@ -90,8 +91,7 @@ class OllamaTypeAdapter(ModelTypeAdapter):
             }
 
         elif isinstance(content, list):
-            prompt = content[0]
-            images = content[1:]
+            prompt, images = split_multimodal_input(content)
 
             if not all(isinstance(image, Image) for image in images):
                 raise ValueError("All assets provided must be of type Image")

--- a/src/outlines/models/openai.py
+++ b/src/outlines/models/openai.py
@@ -16,7 +16,10 @@ from pydantic import BaseModel
 from outlines.exceptions import GenerationError, normalize_provider_errors
 from outlines.inputs import Chat, Image
 from outlines.models.base import AsyncModel, Model, ModelTypeAdapter
-from outlines.models.utils import set_additional_properties_false_json_schema
+from outlines.models.utils import (
+    set_additional_properties_false_json_schema,
+    split_multimodal_input,
+)
 from outlines.types import JsonSchema, Regex, CFG
 from outlines.types.utils import is_native_dict
 
@@ -103,8 +106,7 @@ class OpenAITypeAdapter(ModelTypeAdapter):
             }
 
         elif isinstance(content, list):
-            prompt = content[0]
-            images = content[1:]
+            prompt, images = split_multimodal_input(content)
 
             if not all(isinstance(image, Image) for image in images):
                 raise ValueError("All assets provided must be of type Image")

--- a/src/outlines/models/transformers.py
+++ b/src/outlines/models/transformers.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 from outlines.inputs import Audio, Chat, Image, Video
 from outlines.models.base import Model, ModelTypeAdapter
+from outlines.models.utils import split_multimodal_input
 from outlines.models.tokenizer import Tokenizer, _check_hf_chat_template
 from outlines.processors import OutlinesLogitsProcessor
 
@@ -448,8 +449,7 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
             if all(isinstance(item, dict) for item in content): # HF multimodal chat template
                 return {"role": role, "content": content}, self._extract_assets_from_content(content)
             else: # list of string + assets
-                prompt = content[0]
-                assets = content[1:]
+                prompt, assets = split_multimodal_input(content)
                 assets_dict = [self._format_asset_for_template(asset) for asset in assets]
 
                 return {"role": role, "content": [
@@ -521,8 +521,7 @@ class TransformersMultiModalTypeAdapter(ModelTypeAdapter):
 
     @format_input.register(list)
     def format_list_input(self, model_input: list) -> dict:
-        prompt = model_input[0]
-        assets = model_input[1:]
+        prompt, assets = split_multimodal_input(model_input)
 
         if not assets:  # handle empty assets case
             return {"text": prompt}

--- a/src/outlines/models/utils.py
+++ b/src/outlines/models/utils.py
@@ -1,3 +1,15 @@
+from typing import Any
+
+
+def split_multimodal_input(content: list[Any]) -> tuple[str, list[Any]]:
+    """Split a multimodal input into its text prompt and assets."""
+    if not content:
+        raise ValueError("Content list cannot be empty.")
+    if not isinstance(content[0], str):
+        raise ValueError("The first item in the content list must be a string.")
+    return content[0], content[1:]
+
+
 def set_additional_properties_false_json_schema(schema: dict) -> dict:
     """Set additionalProperties to False on all object schemas.
 

--- a/tests/models/test_mistral_type_adapter.py
+++ b/tests/models/test_mistral_type_adapter.py
@@ -108,7 +108,7 @@ def test_mistral_type_adapter_input_invalid(adapter, image):
 
     with pytest.raises(
         ValueError,
-        match="The first item in the list should be a string.",
+        match="The first item in the content list must be a string.",
     ):
         adapter.format_input([Image(image)])
 

--- a/tests/models/test_openai_type_adapter.py
+++ b/tests/models/test_openai_type_adapter.py
@@ -122,6 +122,12 @@ def test_openai_type_adapter_input_invalid(adapter):
     ):
         _ = adapter.format_input(["prompt", Audio("file")])
 
+    with pytest.raises(ValueError, match="Content list cannot be empty"):
+        _ = adapter.format_input([])
+
+    with pytest.raises(ValueError, match="first item.*must be a string"):
+        _ = adapter.format_input([Image])
+
     with pytest.raises(
         ValueError,
         match="The content must be a string or a list",

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,4 +1,19 @@
-from outlines.models.utils import set_additional_properties_false_json_schema
+import pytest
+
+from outlines.models.utils import (
+    set_additional_properties_false_json_schema,
+    split_multimodal_input,
+)
+
+
+def test_split_multimodal_input():
+    assert split_multimodal_input(["prompt", "asset"]) == ("prompt", ["asset"])
+
+
+@pytest.mark.parametrize("content", [[], [object()]])
+def test_split_multimodal_input_rejects_missing_text_prompt(content):
+    with pytest.raises(ValueError):
+        split_multimodal_input(content)
 
 
 def test_set_additional_properties_false_json_schema():


### PR DESCRIPTION
## Summary

- validate the shared `[text, *assets]` multimodal input contract before provider-specific formatting
- return actionable `ValueError`s for empty lists and non-string first items instead of leaking `IndexError` or passing invalid prompts to SDKs
- apply the same boundary to OpenAI, Anthropic, Gemini, Ollama, Mistral, LM Studio, and Transformers adapters
- add focused helper and OpenAI entry-point regressions, while retaining Mistral's existing behavior through the shared helper

## Root cause

Most model adapters indexed `content[0]` directly and validated only the remaining assets. An empty list therefore crashed with `IndexError`; a list starting with an image or another object passed that value through as the provider's text prompt. Mistral already performed both validations independently, so the rules also drifted between adapters.

This change centralizes the documented multimodal input boundary in `split_multimodal_input`, keeping provider-specific asset conversion separate.

## Validation

- locked project environment: 48 adapter/unit tests passed
- core environment: 36 adapter/unit tests passed
- Ruff 0.9.1 on all changed files
- mypy (`--allow-redefinition`) on all changed source files
- `git diff --check`

The pre-commit wrapper could not finish cloning its hook environments over the local Git transport; its Ruff and mypy commands were run directly at the repository-pinned versions instead.

## Checklist

- [x] The title describes the change
- [x] This PR contains one logical bug fix
- [x] Naming and NumPy-style docstrings follow the project conventions
- [x] Tests cover the changed behavior
- [x] No documentation change is needed; the accepted input contract is unchanged
