### PR TITLE
fix: forward falsy logits processor in mlxlm format_output_type

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -94,9 +94,9 @@ class MLXLMTypeAdapter(ModelTypeAdapter):
             The logits processor argument to be passed to the model.
 
         """
-        if not output_type:
-            return None
-        return [output_type]
+        if output_type is not None:
+            return [output_type]
+        return None
 
 
 class MLXLM(Model):

--- a/tests/models/test_mlxlm_type_adapter.py
+++ b/tests/models/test_mlxlm_type_adapter.py
@@ -111,3 +111,20 @@ def test_mlxlm_type_adapter_format_output_type(adapter, logits_processor):
     assert isinstance(formatted, list)
     assert len(formatted) == 1
     assert isinstance(formatted[0], OutlinesCoreLogitsProcessor)
+
+
+def test_mlxlm_type_adapter_format_output_type_none():
+    adapter = MLXLMTypeAdapter(tokenizer=MagicMock())
+    assert adapter.format_output_type(None) is None
+
+
+def test_mlxlm_type_adapter_format_output_type_falsy_processor():
+    # A processor that is falsy (e.g. __bool__/__len__ returns False) must
+    # still be forwarded — only None means "no constraint".
+    class FalsyProcessor:
+        def __bool__(self):
+            return False
+
+    adapter = MLXLMTypeAdapter(tokenizer=MagicMock())
+    processor = FalsyProcessor()
+    assert adapter.format_output_type(processor) == [processor]


### PR DESCRIPTION
Closes #1980. `MLXLMTypeAdapter.format_output_type` used `if not output_type` to decide whether a logits processor was supplied. That's a truthiness check, so any processor whose `__bool__` (or `__len__`) evaluates to `False` gets silently dropped and generation runs unconstrained — no error, just wrong output. Only `None` should mean "no constraint".

Switched to the identity check `if output_type is not None`, matching `transformers.py`, `llamacpp.py` and the other backends.

Added two tests that don't need Apple Silicon (they build the adapter with a mock tokenizer): one for the `None` case and one for a falsy processor. The falsy-processor test fails on the old code and passes on the fix.
