### PR TITLE
fix(mlxlm): guard generate_batch output_type with 'is not None'

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -198,7 +198,7 @@ class MLXLM(Model):
         """
         from mlx_lm import batch_generate
 
-        if output_type:
+        if output_type is not None:
             raise NotImplementedError(
                 "mlx-lm does not support constrained generation with batching."
                 + "You cannot provide an `output_type` with this method."


### PR DESCRIPTION
`MLXLMModel.generate_batch` guards against structured generation (which mlx-lm can't do with batching) using a truthy check:

```python
if output_type:
    raise NotImplementedError(
        "mlx-lm does not support constrained generation with batching."
        ...
    )
```

Every other place in the codebase that inspects `output_type` uses an identity check (`is None` / `is not None`); this is the only `if output_type:` in the repo. The difference matters here: if an `output_type` is provided that happens to be falsy, for example an object whose `__bool__` returns `False`, the guard is skipped and `batch_generate` runs with no constraint. The caller asked for structured output and silently gets unconstrained text instead of the `NotImplementedError` they should get.

Switching to `is not None` makes the guard fire for any provided output type and matches the convention used everywhere else.

The mlxlm test module is gated behind `@pytest.mark.skipif(not HAS_MLX, ...)` and needs a real model, so there is no CI-runnable spot to add a case; this is a one-line guard correction that can't change the `None` (default) or normal-object paths.