### PR TITLE
Fix falsy MLX batch output types

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -198,7 +198,7 @@ class MLXLM(Model):
         """
         from mlx_lm import batch_generate
 
-        if output_type:
+        if output_type is not None:
             raise NotImplementedError(
                 "mlx-lm does not support constrained generation with batching."
                 + "You cannot provide an `output_type` with this method."

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -155,3 +155,19 @@ def test_mlxlm_batch_output_type(model):
             ["Respond with one word.", "Respond with one word."],
             Regex(r"[0-9]")
         )
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX tests require Apple Silicon")
+def test_mlxlm_batch_falsy_output_type(model):
+    class FalsyOutputType:
+        def __bool__(self):
+            return False
+
+    with pytest.raises(
+        NotImplementedError,
+        match="mlx-lm does not support constrained generation with batching."
+    ):
+        model.generate_batch(
+            ["Respond with one word.", "Respond with one word."],
+            FalsyOutputType(),
+        )


### PR DESCRIPTION
Fixes #1997

## Summary
- treat every non-`None` MLX batch output type as an unsupported constraint
- add a regression for output type objects whose boolean value is false

## Why
The previous truthiness guard silently allowed falsy output type objects through to unconstrained batch generation.

## Validation
- `python3 -m compileall -q src/outlines/models/mlxlm.py tests/models/test_mlxlm.py`
- `git diff --check`
- focused pytest collection is unavailable locally because the optional `transformers` dependency is not installed