### PR TITLE
Give the mypy pre-commit hook urllib3 so the style check passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: mypy
       args: [--allow-redefinition]
       exclude: ^examples/
-      additional_dependencies: [types-tqdm, types-Pillow]
+      additional_dependencies: [types-tqdm, types-Pillow, urllib3]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.9.1
   hooks:


### PR DESCRIPTION
`main` currently fails the **Check the code style** job:

```
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3.exceptions"  [import-not-found]
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3"  [import-not-found]
tests/test_exceptions.py:714: error: Cannot find implementation or library stub for module named "urllib3.exceptions"  [import-not-found]
```

5527d3e3 added `import urllib3.exceptions` to the `dottxt` branch of `_provider_error_map`, but the pre-commit mypy hook runs in an isolated environment built from `additional_dependencies`, which lists only `types-tqdm` and `types-Pillow`. mypy cannot resolve the import, so the job fails on main and on every branch cut from it.

Reproduced on a clean checkout of `origin/main`: 3 errors. With `urllib3` added to `additional_dependencies`, `pre-commit run mypy --all-files` passes.

urllib3 ships inline type information (`py.typed`), so the runtime package is enough — there is no `types-urllib3` stub needed for v2.

Noticed while looking into an unrelated red style check on #2002, which is not caused by that PR.