### PR TITLE
fix: reject unsupported whitespace_pattern in SGLang and TGI adapters

### DIFF
--- a/docs/features/core/output_types.md
+++ b/docs/features/core/output_types.md
@@ -178,7 +178,7 @@ output_type = JsonSchema(schema_dict)
 ```
 
 `JsonSchema` accepts two optional parameters:
-- `whitespace_pattern` (defaults to `None`): specifies the pattern to use for JSON syntactic whitespace. If none is provided, the default permissive JSON whitespace rules are used. It is applied by the `outlines_core` backend; the `llguidance` and `xgrammar` backends do not support it and raise an error if one is set.
+- `whitespace_pattern` (defaults to `None`): specifies the pattern to use for JSON syntactic whitespace. If none is provided, the default permissive JSON whitespace rules are used. It is applied by the `outlines_core` backend; the `llguidance` and `xgrammar` backends, and the `SGLang` and `TGI` model integrations, do not support it and raise an error if one is set.
 - `ensure_ascii` (defaults to `True`): defines the value to use for the argument `ensure_ascii` of the `json.dumps` method. If false, non-ASCII characters will be turned into unicodes.
 
 ### Regex Patterns

--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -75,6 +75,13 @@ class SGLangTypeAdapter(ModelTypeAdapter):
             )
             return {"extra_body": {"ebnf": term.definition}}
         elif isinstance(term, JsonSchema):
+            if term.whitespace_pattern is not None:
+                raise NotImplementedError(
+                    "The SGLang backend does not support the "
+                    "`whitespace_pattern` argument. Set the whitespace "
+                    "pattern on the SGLang server instead, e.g. with "
+                    "`--constrained-json-whitespace-pattern`."
+                )
             return OpenAITypeAdapter().format_json_output_type(
                 json.loads(term.schema)
             )

--- a/src/outlines/models/tgi.py
+++ b/src/outlines/models/tgi.py
@@ -73,6 +73,11 @@ class TGITypeAdapter(ModelTypeAdapter):
                 "TGI does not support CFG-based structured outputs."
             )
         elif isinstance(term, JsonSchema):
+            if term.whitespace_pattern is not None:
+                raise NotImplementedError(
+                    "The TGI backend does not support the "
+                    "`whitespace_pattern` argument."
+                )
             return {
                 "grammar": {
                     "type": "json",

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -149,20 +149,9 @@ def test_sglang_type_adapter_output_type(
             },
         }
     }
-    # whitespace pattern is ignored
-    assert type_adapter.format_output_type(json_schema_whitespace_instance) == {
-        "response_format": {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "default",
-                "strict": True,
-                "schema": {
-                    **json.loads(JSON_SCHEMA_STRING),
-                    "additionalProperties": False,
-                },
-            },
-        }
-    }
+    # the SGLang server only supports a server-side whitespace pattern
+    with pytest.raises(NotImplementedError, match="whitespace_pattern"):
+        type_adapter.format_output_type(json_schema_whitespace_instance)
     assert type_adapter.format_output_type(int) == {
         "extra_body": {"regex": "([+-]?(0|[1-9][0-9]*))"}
     }

--- a/tests/models/test_tgi_model_adapter.py
+++ b/tests/models/test_tgi_model_adapter.py
@@ -62,13 +62,9 @@ def test_tgi_type_adapter_output_type(
             "value": json.loads(JSON_SCHEMA_STRING),
         }
     }
-    # whitespace_pattern is ignored
-    assert type_adapter.format_output_type(json_schema_whitespace_instance) == {
-        "grammar": {
-            "type": "json",
-            "value": json.loads(JSON_SCHEMA_STRING),
-        }
-    }
+    # TGI does not support per-request whitespace patterns
+    with pytest.raises(NotImplementedError, match="whitespace_pattern"):
+        type_adapter.format_output_type(json_schema_whitespace_instance)
     assert type_adapter.format_output_type(int) == {
         "grammar": {
             "type": "regex",


### PR DESCRIPTION
Closes #1998

`SGLangTypeAdapter` was silently dropping `JsonSchema.whitespace_pattern`. The SGLang OpenAI-compatible API doesn't accept a per-request whitespace pattern — it's only configurable at server startup via `--constrained-json-whitespace-pattern` — so mirroring the vLLM adapter and stuffing the field into `response_format` would have been a silent no-op. I made the adapter raise a clear `NotImplementedError` instead, which is what the `llguidance` and `xgrammar` backends already do for the same reason.

The TGI adapter had the exact same gap (TGI's grammar API has no whitespace option either), so it now raises too.

- `SGLangTypeAdapter`: raise when `whitespace_pattern` is set, with a pointer to the server-side flag
- `TGITypeAdapter`: raise when `whitespace_pattern` is set
- Updated both adapter tests that previously asserted the ignored behavior
- Docs: noted that the SGLang and TGI integrations reject `whitespace_pattern`

Verified against the SGLang and TGI servers: neither exposes a per-request whitespace pattern (only the SGLang server flag). Tested with the repo-pinned ruff 0.9.1 (clean) and the sglang/tgi/vllm adapter tests.

Developed with AI assistance and reviewed before submission.