### PR TITLE
fix(types): make string and numeric types match the JSON grammar

### DIFF
--- a/src/outlines/types/__init__.py
+++ b/src/outlines/types/__init__.py
@@ -103,8 +103,8 @@ __all__ = [
 
 
 # Python types
-string = Regex(r'"[^"]*"')
-integer = Regex(r"[+-]?(0|[1-9][0-9]*)")
+string = Regex(r'"([^"\\\x00-\x1F\x7F-\x9F]|\\["\\/bfnrt])*"')
+integer = Regex(r"-?(0|[1-9][0-9]*)")
 boolean = Regex("(True|False)")
 number = Regex(rf"{integer.pattern}(\.[0-9]+)?([eE][+-]?[0-9]+)?")
 date = Regex(r"(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])")

--- a/tests/types/test_custom_types.py
+++ b/tests/types/test_custom_types.py
@@ -34,6 +34,8 @@ from outlines.types.dsl import to_regex
         (types.integer, "019", False),
         (types.integer, "1.9", False),
         (types.integer, "a", False),
+        (types.integer, "+5", False),  # JSON numbers have no leading +
+        (types.number, "+10", False),  # JSON numbers have no leading +
         (types.boolean, "True", True),
         (types.boolean, "False", True),
         (types.boolean, "true", False),
@@ -277,3 +279,45 @@ def test_type_enum(custom_type, test_string, should_match):
 
     does_match = test_string in custom_type.__members__
     assert does_match is should_match
+
+
+def test_scalar_string_matches_json_escapes():
+    """types.string only accepts valid JSON strings, including the standard escapes."""
+    bs = chr(92)  # backslash
+
+    # Standard JSON escape sequences are allowed
+    assert types.string.matches('"a' + bs + '"b"')  # "a\"b"
+    assert types.string.matches('"a' + bs + bs + 'b"')  # "a\\b"
+    assert types.string.matches('"a' + bs + '/b"')  # "a\/b"
+    assert types.string.matches('"a' + bs + 'nb"')  # "a\nb"
+    assert types.string.matches('"a' + bs + 'tb"')  # "a\tb"
+    assert types.string.matches('"a' + bs + 'fb"')  # "a\fb"
+    assert types.string.matches('"a' + bs + 'rb"')  # "a\rb"
+    assert types.string.matches('"a' + bs + 'bb"')  # "a\bb"
+
+    # Raw control characters, unescaped quotes and unknown escapes are not valid JSON
+    assert not types.string.matches('"a' + chr(10) + 'b"')
+    assert not types.string.matches('"a' + chr(9) + 'b"')
+    assert not types.string.matches('"a"b"')
+    assert not types.string.matches('"a' + bs + 'qb"')  # \q is not a JSON escape
+
+
+def test_scalar_numbers_reject_leading_plus():
+    """JSON numbers have no leading '+', matching the JSON-schema path."""
+    assert not types.integer.matches("+5")
+    assert not types.number.matches("+10")
+    assert not types.number.matches("+.5")
+    assert types.integer.matches("-5")
+    assert types.number.matches("-10.5e+3")
+
+
+def test_string_container_accepts_json_escapes():
+    """list[str] output containing an escaped quote is valid JSON."""
+    from typing import List
+
+    from outlines.types.dsl import python_types_to_terms, to_regex
+
+    list_regex = to_regex(python_types_to_terms(List[str]))
+    bs = chr(92)
+    assert re.fullmatch(list_regex, '["a' + bs + '"b"]')  # ["a\"b"]
+    assert not re.fullmatch(list_regex, '["a"b"]')  # unescaped quote


### PR DESCRIPTION
## Summary

Two places where the built-in scalar types accept or reject strings that the JSON grammar doesn't, diverging from the JSON-schema path:

**1. `types.string` can't match JSON escape sequences.** The pattern was `"[^"]*"`, so a string containing an escaped quote (`"a\"b"`) or any other standard escape (`\n`, `\t`, `\\`, ...) could never be generated — the model was forced into producing output `json.loads` would reject. It also happily matched raw control characters, which are not valid inside JSON strings. The pattern now mirrors the JSON-schema generator: `"([^"\\\x00-\x1F\x7F-\x9F]|\\["\\/bfnrt])*"`.

**2. `types.integer` / `types.number` accept a leading `+`.** The patterns used `[+-]?`, so `+10` matched even though JSON numbers have no leading plus (the JSON-schema path only allows `-`). `json.loads("+10")` raises, so constrained generation could emit unparseable output. The patterns now use `-?`.

Before/after:

```python
>>> from outlines import types

>>> types.string.matches('"a\\"b"')   # escaped quote
False  # -> True
>>> types.number.matches("+10")
True   # -> False

>>> import json
>>> json.loads('["a\\"b"]')   # what list[str] should be able to produce
['a"b']
```

Notes:
- The string pattern deliberately matches the JSON-schema generator's escape set (`" \ / b f n r t`); `\uXXXX` escapes are unsupported by both paths and left as-is.
- `number` is composed from `integer.pattern`, so fixing `integer` carries through.

## Verification

- `pytest tests/types/` — 546 passed; the only 2 failures (`test_dsl_cfg_from_file`, `test_dsl_json_schema_from_file`) are pre-existing Windows temp-file permission errors that also fail on a clean checkout of `main`.
- `ruff check` (repo-pinned 0.9.1) on the changed files — clean.
- New parametrized cases and regression tests cover the JSON escapes, the leading-plus rejection, and container output.

Developed with AI assistance and reviewed before submission.
