### PR TITLE
fix: make JsonSchema and CFG hashable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,8 @@ module = [
     "mkdocs_gen_files.*",
     "llguidance.*",
     "xgrammar.*",
+    "urllib3",
+    "urllib3.*",
 ]
 ignore_missing_imports = true
 

--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -260,6 +260,9 @@ class CFG(Term):
             return False
         return self.definition == other.definition
 
+    def __hash__(self):
+        return hash(self.definition)
+
     @classmethod
     def from_file(cls, path: str) -> "CFG":
         """Create a CFG instance from a file containing a CFG definition.
@@ -459,6 +462,13 @@ class JsonSchema(Term):
                 self.schema == other.schema
                 and self.whitespace_pattern == other.whitespace_pattern
             )
+
+    def __hash__(self):
+        try:
+            normalised = json.dumps(json.loads(self.schema), sort_keys=True)
+        except json.JSONDecodeError:  # pragma: no cover
+            normalised = self.schema
+        return hash((normalised, self.whitespace_pattern))
 
     @classmethod
     def from_file(cls, path: str) -> "JsonSchema":

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -545,6 +545,42 @@ def test_json_schema_equality_includes_whitespace_pattern():
     assert JsonSchema(schema) != JsonSchema(schema, whitespace_pattern=r"[ ]?")
 
 
+def test_json_schema_is_hashable():
+    schema = {"type": "string"}
+
+    a = JsonSchema(schema)
+    b = JsonSchema(schema)
+    assert hash(a) == hash(b), "equal JsonSchema instances must hash equally"
+    assert len({a, b}) == 1, "equal JsonSchema instances deduplicate in a set"
+    assert {a: "value"}[b] == "value", "JsonSchema is usable as a dict key"
+
+    different = JsonSchema({"type": "number"})
+    assert hash(a) != hash(different)
+
+    whitespace = JsonSchema(schema, whitespace_pattern=r"[ ]?")
+    assert hash(a) != hash(whitespace)
+
+
+def test_json_schema_hash_key_order_insensitive():
+    a = JsonSchema(
+        {"type": "object", "properties": {"x": {"type": "string"}}}
+    )
+    b = JsonSchema(
+        {"properties": {"x": {"type": "string"}}, "type": "object"}
+    )
+    assert a == b
+    assert hash(a) == hash(b), "schemas equal under __eq__ must hash equally"
+
+
+def test_cfg_is_hashable():
+    a = CFG("root ::= [0-9]+")
+    b = CFG("root ::= [0-9]+")
+    assert hash(a) == hash(b), "equal CFG instances must hash equally"
+    assert len({a, b}) == 1
+    assert {a: "value"}[b] == "value", "CFG is usable as a dict key"
+    assert hash(a) != hash(CFG("root ::= [0-9]*"))
+
+
 def test_dsl_python_types_to_terms():
     with pytest.raises(RecursionError):
         python_types_to_terms(None, 11)


### PR DESCRIPTION
## Problem

`JsonSchema` and `CFG` both define `__eq__` without defining `__hash__`. Per the Python data model, this silently sets `__hash__ = None`, making instances unhashable — any code that stores output types in a `set` or uses them as `dict` keys (cache key construction, deduplication) fails at runtime with `TypeError: unhashable type`.

Fixes #1996.

## Fix

Add `__hash__` implementations consistent with the existing `__eq__` semantics:

- `JsonSchema.__hash__` — hashes the sorted-key normalised JSON schema plus `whitespace_pattern`, so schemas that are equal under `__eq__` (including key-order differences) hash equally. Falls back to the raw string when the schema is not valid JSON, mirroring `__eq__`.
- `CFG.__hash__` — hashes `self.definition`, mirroring `CFG.__eq__`.

## Tests

Added to `tests/types/test_dsl.py`:

- `test_json_schema_is_hashable` — equal instances hash equally and deduplicate in a set; usable as a dict key; different schemas and different `whitespace_pattern` hash differently.
- `test_json_schema_hash_key_order_insensitive` — key-order differences hash equally, matching `__eq__`.
- `test_cfg_is_hashable` — equal CFG instances hash equally; usable as a dict key.

```
/tmp/outlines-venv/bin/python -m pytest tests/types/test_dsl.py -q
63 passed in 0.68s
```

`ruff check` (v0.9.1, project config) passes on both changed files.
