### PR TITLE
fix(ci): add urllib3 to mypy pre-commit additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: mypy
       args: [--allow-redefinition]
       exclude: ^examples/
-      additional_dependencies: [types-tqdm, types-Pillow]
+      additional_dependencies: [types-tqdm, types-Pillow, urllib3]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.9.1
   hooks:


### PR DESCRIPTION
## Problem

`src/outlines/exceptions.py` imports `urllib3.exceptions` inside the `dottxt` provider branch, and `urllib3` is not a project dependency. The `mirrors-mypy` pre-commit hook therefore fails on any **freshly built** mypy environment:

```
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3.exceptions"  [import-not-found]
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3"  [import-not-found]
tests/test_exceptions.py:714: error: Cannot find implementation or library stub for module named "urllib3.exceptions"  [import-not-found]
```

This is latent breakage: CI runs that hit a **cached** mypy environment (one built earlier, containing urllib3) stay green, so main passes while fresh PR runs (cache miss) fail the style check. Reproducible: `pre-commit run --all-files` with a cold cache on current main.

## Fix

Add `urllib3` to the mypy hook's `additional_dependencies` so the isolated environment always resolves the import.

## Verification

```
mypy==1.14.1 + types-tqdm + types-Pillow + urllib3 in a scratch venv:
/tmp/mypy-check/bin/mypy --allow-redefinition src/outlines/exceptions.py tests/test_exceptions.py
Success: no issues found in 2 source files
```

This unblocks #2007 / #2008, whose style checks hit the same cache miss.
