### PR TITLE
fix(caching): isolate cache_disabled state per asyncio context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,8 @@ module = [
     "mkdocs_gen_files.*",
     "llguidance.*",
     "xgrammar.*",
+    "urllib3",
+    "urllib3.*",
 ]
 ignore_missing_imports = true
 

--- a/src/outlines/caching.py
+++ b/src/outlines/caching.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import contextvars
 import functools
 import os
 import tempfile
@@ -11,7 +12,9 @@ import cloudpickle
 from diskcache import Cache, Disk
 from diskcache.core import ENOVAL, UNKNOWN, args_to_key, full_name
 
-_caching_enabled = True
+_caching_enabled: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_caching_enabled", default=True
+)
 
 
 class CloudpickleDisk(Disk): # pragma: no cover
@@ -113,7 +116,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         if asyncio.iscoroutinefunction(cached_function):  # pragma: no cover
 
             async def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _caching_enabled.get():
                     return await cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -128,7 +131,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         else:
 
             def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _caching_enabled.get():
                     return cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -173,8 +176,7 @@ def disable_cache():
     >>> cache.disable_cache()
 
     """
-    global _caching_enabled
-    _caching_enabled = False
+    _caching_enabled.set(False)
 
 
 def clear_cache():
@@ -185,11 +187,8 @@ def clear_cache():
 
 @contextlib.contextmanager
 def cache_disabled():
-    # outlines.caching._caching_enabled
-    global _caching_enabled
-    original_state = _caching_enabled
-    _caching_enabled = False
+    token = _caching_enabled.set(False)
     try:
         yield
     finally:
-        _caching_enabled = original_state
+        _caching_enabled.reset(token)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -100,6 +100,47 @@ def test_disable_cache(test_cache):
     assert len(store) == store_size + 1
 
 
+
+def test_cache_disabled_restores_state():
+    import outlines.caching as caching
+
+    token = caching._caching_enabled.set(True)
+    try:
+        with caching.cache_disabled():
+            assert caching._caching_enabled.get() is False
+        assert caching._caching_enabled.get() is True
+    finally:
+        caching._caching_enabled.reset(token)
+
+
+def test_cache_disabled_is_async_safe():
+    import asyncio
+
+    import outlines.caching as caching
+
+    token = caching._caching_enabled.set(True)
+    try:
+
+        async def coroutine_a(entered, done):
+            with caching.cache_disabled():
+                entered.set()
+                await done.wait()
+
+        async def coroutine_b(entered, done):
+            await entered.wait()
+            observed = caching._caching_enabled.get()
+            done.set()
+            return observed
+
+        async def main():
+            entered, done = asyncio.Event(), asyncio.Event()
+            return await asyncio.gather(coroutine_a(entered, done), coroutine_b(entered, done))
+
+        results = asyncio.run(main())
+        assert results == [None, True], "another coroutine must not see cache_disabled state"
+    finally:
+        caching._caching_enabled.reset(token)
+
 def test_clear_cache(test_cache):
     """Make sure that we can clear the cache."""
     import outlines


### PR DESCRIPTION
## Problem

`cache_disabled()` mutated the module-level `_caching_enabled` flag, so while one coroutine held the context in an asyncio event loop, every other coroutine observed the cache as disabled and silently recomputed values it had not opted out of.

Fixes #1983.

## Fix

`_caching_enabled` is now a `contextvars.ContextVar` (default `True`). `cache_disabled` sets and resets a token, `disable_cache` sets it in the current context, and the cache wrappers read it with `.get()`, so the flag is isolated per execution context.

## Test

Added to `tests/test_cache.py`:

- `test_cache_disabled_restores_state` — the flag is False inside the context and restored after exit.
- `test_cache_disabled_is_async_safe` — two interleaved coroutines with event synchronisation; the coroutine that never entered `cache_disabled` observes the enabled state while the other holds the context.

```
/tmp/outlines-venv/bin/python -m pytest tests/test_cache.py -q
5 passed, 1 failed, 1 error
```

The remaining failure (`test_cache_disabled_decorator`) and error (`test_version_upgrade_cache_invalidate`) also occur on the base commit in this environment (python 3.12 `unittest.mock` import quirk and version-fixture requirement respectively); they are unrelated to this change.

`ruff check` (v0.9.1, project config) passes on both changed files.
