### PR TITLE
fix(sglang): forward whitespace_pattern for JsonSchema structured outputs

### DIFF
--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -75,9 +75,10 @@ class SGLangTypeAdapter(ModelTypeAdapter):
             )
             return {"extra_body": {"ebnf": term.definition}}
         elif isinstance(term, JsonSchema):
-            return OpenAITypeAdapter().format_json_output_type(
-                json.loads(term.schema)
-            )
+            structured_outputs = {"json": json.loads(term.schema)}
+            if term.whitespace_pattern:
+                structured_outputs["whitespace_pattern"] = term.whitespace_pattern
+            return structured_outputs
         else:
             return {"extra_body": {"regex": to_regex(term)}}
 


### PR DESCRIPTION
Fixes dottxt-ai/outlines#1998

## Summary
`SGLangTypeAdapter.format_output_type` passed `json.loads(term.schema)` to the OpenAI adapter, silently dropping `whitespace_pattern`. The vLLM backend already forwards it (`structured_outputs["whitespace_pattern"]`), so SGLang users got no whitespace constraint with no error.

Changed the JsonSchema branch to build `structured_outputs` directly and include `whitespace_pattern` when set, mirroring the vLLM implementation.
