### PR TITLE
fix(dsl): make JsonSchema and CFG hashable

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -237,7 +237,7 @@ class Regex(Term):
         return f"Regex(pattern='{self.pattern}')"
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class CFG(Term):
     """Class representing a context-free grammar.
 
@@ -459,6 +459,13 @@ class JsonSchema(Term):
                 self.schema == other.schema
                 and self.whitespace_pattern == other.whitespace_pattern
             )
+
+    def __hash__(self):
+        try:
+            normalised = json.dumps(json.loads(self.schema), sort_keys=True)
+        except json.JSONDecodeError:  # pragma: no cover
+            normalised = self.schema
+        return hash((normalised, self.whitespace_pattern))
 
     @classmethod
     def from_file(cls, path: str) -> "JsonSchema":


### PR DESCRIPTION
Fixes dottxt-ai/outlines#1996

## Summary
`JsonSchema` and `CFG` define `__eq__` without `__hash__`, which per the Python data model sets `__hash__ = None`, making both types unhashable (can't be used in `set` or as `dict` keys).

- `JsonSchema`: added `__hash__` on the normalised schema (sorted keys) plus `whitespace_pattern`, consistent with the existing `__eq__` semantics.
- `CFG`: added `unsafe_hash=True` to the `@dataclass` decorator so the dataclass generates `__hash__` from `definition`, consistent with its `__eq__`.
