### PR TITLE
fix(mlxlm): use identity check for output_type in generate_batch

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -198,7 +198,7 @@ class MLXLM(Model):
         """
         from mlx_lm import batch_generate
 
-        if output_type:
+        if output_type is not None:
             raise NotImplementedError(
                 "mlx-lm does not support constrained generation with batching."
                 + "You cannot provide an `output_type` with this method."


### PR DESCRIPTION
Fixes dottxt-ai/outlines#1997

## Summary
`MLXLMModel.generate_batch` guarded structured generation with `if output_type:`, a falsy check. Any truthy-but-falsy output type object (e.g. a logits processor with `__bool__` returning `False`) would silently bypass the guard and call `batch_generate` without the constraint.

Changed to `if output_type is not None:`, consistent with the rest of the codebase.
