### PR TITLE
fix(mlxlm): use identity check for output_type in format_output_type

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -94,7 +94,7 @@ class MLXLMTypeAdapter(ModelTypeAdapter):
             The logits processor argument to be passed to the model.
 
         """
-        if not output_type:
+        if output_type is None:
             return None
         return [output_type]
 


### PR DESCRIPTION
Fixes dottxt-ai/outlines#1980

## Summary
`MLXLMTypeAdapter.format_output_type` used `if not output_type` instead of `if output_type is None`. A logits processor whose `__bool__` returns `False` would be silently discarded and generation would proceed unconstrained.

Changed to `if output_type is None`, matching the identity checks used everywhere else.
