### PR TITLE
fix(types): JSON-quote string-shaped built-in terms inside containers

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -865,24 +865,59 @@ def _handle_literal(args: tuple) -> Alternatives:
     return Alternatives([python_types_to_terms(arg) for arg in args])
 
 
+def _json_string_builtin_patterns() -> set:
+    """Patterns of the built-in terms that JSON reads as strings.
+
+    The scalars are listed rather than the terms to quote, so a built-in added
+    later is quoted by default. An allowlist has to be extended with every new
+    term and fails open when it isn't, which is how the missing quotes got
+    here in the first place.
+
+    ``types.string`` is excluded because its pattern carries the quotes
+    already. ``latitude`` and ``longitude`` stay bare despite the leading
+    ``+`` JSON rejects; that is a separate bug from the quoting one.
+    """
+    json_scalars = {
+        types.integer.pattern,
+        types.number.pattern,
+        types.boolean.pattern,
+        types.digit.pattern,
+        types.latitude.pattern,
+        types.longitude.pattern,
+        types.string.pattern,
+    }
+    return {
+        term.pattern
+        for module in (types, types.locale.us)
+        for term in vars(module).values()
+        if isinstance(term, Regex) and term.pattern not in json_scalars
+    }
+
+
 def _ensure_json_quoted(term: Term, quote_regex: bool = False) -> Term:
     """Wrap ``String`` terms in double quotes for JSON container contexts.
 
     String literals (from ``Literal``/``Enum``) inside containers must be
-    JSON-quoted so the generated regex matches valid JSON. With
-    ``quote_regex``, bare ``Regex`` terms are quoted too (needed for ``Dict``
-    keys, which JSON always requires to be strings); ``types.string`` is never
-    re-quoted since its pattern already includes the quotes. Both cases recurse
-    into ``Alternatives``, so ``Regex`` members nested there (e.g.
-    ``Dict[Literal[1, 2], str]``) are quoted as well.
+    JSON-quoted so the generated regex matches valid JSON, and so must the
+    built-in ``Regex`` terms JSON reads as strings (``types.email``,
+    ``types.date``, ...), matched on their pattern so a copy or a
+    reconstruction is treated the same as the module-level term. Any other
+    ``Regex`` is left alone, since nothing records whether it stands for a
+    JSON string or a number. With ``quote_regex``, every bare ``Regex``
+    is quoted (needed for ``Dict`` keys, which JSON always requires to be
+    strings); ``types.string`` is never re-quoted since its pattern already
+    includes the quotes. All cases recurse into ``Alternatives``, so ``Regex``
+    members nested there (e.g. ``Dict[Literal[1, 2], str]``) are quoted as
+    well.
     """
     if isinstance(term, String):
         return String(f'"{term.value}"')
     if isinstance(term, Alternatives):
         quoted = [_ensure_json_quoted(t, quote_regex) for t in term.terms]
         return Alternatives(quoted)
-    if quote_regex and isinstance(term, Regex) and term.pattern != types.string.pattern:
-        return Sequence([String('"'), term, String('"')])
+    if isinstance(term, Regex) and term.pattern != types.string.pattern:
+        if quote_regex or term.pattern in _json_string_builtin_patterns():
+            return Sequence([String('"'), term, String('"')])
     return term
 
 

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -995,6 +995,117 @@ def test_ensure_json_quoted_regex_passthrough():
     assert _ensure_json_quoted(types.boolean) is types.boolean
 
 
+@pytest.mark.parametrize(
+    "term",
+    [
+        types.integer,
+        types.number,
+        types.boolean,
+        types.digit,
+        types.latitude,
+        types.longitude,
+        types.string,
+    ],
+)
+def test_json_scalar_builtins_stay_bare_in_containers(term):
+    """JSON scalars (and self-quoting `string`) must not gain quotes."""
+    assert _ensure_json_quoted(term) is term
+
+    item = _handle_list((term,), recursion_depth=0).terms[1]
+    assert item is term
+
+
+@pytest.mark.parametrize(
+    "term",
+    [
+        types.email,
+        types.uuid4,
+        types.ipv4,
+        types.ipv6,
+        types.mac_address,
+        types.semver,
+        types.slug,
+        types.hex_color,
+        types.hex_str,
+        types.credit_card,
+        types.char,
+        types.bic,
+        types.e164,
+        types.iban,
+        types.date,
+        types.time,
+        types.datetime,
+        types.locale.us.zip_code,
+        types.locale.us.phone_number,
+    ],
+)
+def test_string_shaped_builtins_quoted_in_containers(term):
+    """Built-in terms that are JSON strings are quoted inside containers."""
+    quoted = Sequence([String('"'), term, String('"')])
+
+    assert _ensure_json_quoted(term) == quoted
+    assert _handle_list((term,), recursion_depth=0).terms[1] == quoted
+    assert _handle_dict((str, term), recursion_depth=0).terms[1].term.terms[2] == quoted
+
+
+def test_user_regex_stays_bare_in_containers():
+    """Only built-in terms are quoted; a user's own Regex is left alone."""
+    term = Regex(r"[a-z]+")
+    assert _handle_list((term,), recursion_depth=0).terms[1] is term
+
+
+def test_rebuilt_builtin_term_is_still_quoted():
+    """Matching on the pattern, so a copy of a built-in is quoted like the original."""
+    rebuilt = Regex(types.email.pattern)
+    assert _handle_list((rebuilt,), recursion_depth=0).terms[1] == Sequence(
+        [String('"'), rebuilt, String('"')]
+    )
+
+
+def test_regex_colliding_with_a_builtin_is_quoted():
+    """`Regex(r"\\w")` is `types.char`; the same pattern gets the same treatment."""
+    term = Regex(r"\w")
+    assert _handle_list((term,), recursion_depth=0).terms[1] == Sequence(
+        [String('"'), term, String('"')]
+    )
+
+
+def test_literal_number_stays_bare_in_containers():
+    """`Literal[1]` becomes a Regex but is still a JSON number, not a string."""
+    item = _handle_list((Literal[1, 2],), recursion_depth=0).terms[1]
+    assert item.terms == [Regex("1"), Regex("2")]
+
+
+@pytest.mark.parametrize(
+    "term,sample",
+    [
+        (types.email, "a@b.com"),
+        (types.uuid4, "123e4567-e89b-42d3-a456-426614174000"),
+        (types.ipv4, "192.168.0.1"),
+        (types.mac_address, "00:1A:2B:3C:4D:5E"),
+        (types.semver, "1.2.3"),
+        (types.slug, "my-post"),
+        (types.hex_color, "#ff0000"),
+        (types.e164, "+14155552671"),
+        (types.date, "2024-01-01"),
+        (types.time, "12:30:00"),
+        (types.datetime, "2024-01-01 12:30:00"),
+        (types.locale.us.zip_code, "12345"),
+        (types.locale.us.phone_number, "(415) 555-0100"),
+    ],
+)
+def test_container_of_builtin_generates_parseable_json(term, sample):
+    """A generation the container's regex accepts also survives `json.loads`."""
+    list_pattern = to_regex(python_types_to_terms(list[term]))
+    assert _re.fullmatch(list_pattern, f'["{sample}"]')
+    assert not _re.fullmatch(list_pattern, f"[{sample}]")
+    assert json.loads(f'["{sample}"]') == [sample]
+
+    dict_pattern = to_regex(python_types_to_terms(dict[str, term]))
+    assert _re.fullmatch(dict_pattern, f'{{"k":"{sample}"}}')
+    assert json.loads(f'{{"k":"{sample}"}}') == {"k": sample}
+
+
 def test_list_single_literal():
     """A single-variant Literal inside list is still quoted."""
     list_type = list[Literal["only"]]


### PR DESCRIPTION
Closes #1962. Supersedes #1961, which fixed `date`/`time`/`datetime` only.

## Problem

`list[types.email]` generates `[a@b.com]`. That is not JSON.

```python
import re
import outlines.types as types
from outlines.types.dsl import to_regex, python_types_to_terms

pattern = to_regex(python_types_to_terms(list[types.email]))
re.fullmatch(pattern, '[a@b.com]')      # matches, and json.loads rejects it
re.fullmatch(pattern, '["a@b.com"]')    # no match, valid JSON rejected
```

`_ensure_json_quoted` quotes a bare `Regex` only when called with `quote_regex=True`, which happens for `Dict` keys and nowhere else (`src/outlines/types/dsl.py:884` before this change). So every built-in term reaching a list item, a tuple item or a dict value came back unquoted. Same for `dict[str, types.email]`, which generates `{"k":a@b.com}`.

The quiet case is worse than the loud one. `json.loads` reads a lone control character between brackets as whitespace, so `list[types.newline]` generates text a parser accepts as an empty array:

```python
json.loads('[\n]')     # []
```

The caller asked for one element, the generation produced one, the parse yields zero, and nothing raises.

## Solution

Quote every built-in `outlines.types` term except the ones JSON reads as scalars: `integer`, `number`, `boolean`, `digit`, `latitude`, `longitude`, plus `string`, whose pattern carries the quotes already.

Listing the exceptions rather than the terms to quote is a deliberate choice, and I would rather state it than leave it open. An allowlist has to be extended every time a term is added and fails open when someone forgets, which is how the missing quotes arrived. A denylist fails the other way: a new term gets quoted like the rest, and if it turns out to need more than quoting that is a visible bug instead of silent invalid JSON. @ErenAta16 argued the same case on the issue and did the work of separating the escaping treatments; @Sanjays2402 spotted the gap during review of #1961.

Terms are matched on their pattern, not by identity. Identity looks tighter but breaks under `pickle`, `copy.deepcopy` and any reconstruction, which would silently restore the old output. Matching the pattern also means a `Regex(r"\w")` the caller wrote is treated as `types.char` and quoted, since nothing distinguishes them; `test_regex_colliding_with_a_builtin_is_quoted` pins that. Any other user-supplied `Regex` keeps its current bare behaviour, because nothing records whether it stands for a JSON string or a number.

The `outlines.types.locale.us` terms (`zip_code`, `phone_number`) are included. They have the same bug and live in a submodule.

24 built-in terms are now quoted. 17 are fully correct. The rest need escaping on top of quoting and are out of scope here:

| Term | Why quoting is not enough |
|---|---|
| `newline`, `whitespace` | admit raw control characters |
| `sentence`, `paragraph` | `.*` admits the backslash and a bare quote, so they want `json.dumps`, not a hand-written escape list |
| `datetime` | its separator is `\s`, so a tab passes |
| `email` | the quoted-local-part branch admits a `"` |

For `newline` and `whitespace` quoting still helps, because it converts the silent bad parse into a raised error:

```python
json.loads('[\n]')      # [] on main
json.loads('["\n"]')    # Invalid control character at: line 1 column 3
```

`isbn` is quoted with the rest and nothing observable changes: its four `$` anchors sit inside lookaheads, so once the term is embedded in `\[(...)\]` the alternation is unsatisfiable and `list[types.isbn]` matches nothing either way. Dropping the anchors changes what bare `isbn` accepts, so it needs its own call.

## Scope

Left out on purpose:

- Escaping for the six terms above, and the `isbn` anchors. Each needs a different treatment and `sentence`/`paragraph` want `json.dumps` rather than the mechanism used here.
- `latitude` and `longitude` emit a leading `+` that JSON rejects, and `boolean` emits `True` rather than `true`. Those are separate bugs from the quoting one and the denylist keeps all three bare either way.
- `_ensure_json_quoted` still does not recurse into `Sequence`, `Optional` or the quantifier nodes, so `list[optional(types.email)]` stays unquoted. That predates this change and `test_ensure_json_quoted_sequence_passthrough` freezes it.

## Validation

Base commit 7d06847.

- `pytest tests/types` : 389 passed, up from 346 on 7d06847. 43 tests added; 34 of them fail against the 7d06847 source and pass here, and the 9 that pass on both pin the scalar and user-supplied-`Regex` behaviour that must not change.
- `ruff check --config=pyproject.toml src/outlines/types/dsl.py tests/types/test_dsl.py` (0.9.1, the pinned pre-commit version): all checks passed.
- `mypy --allow-redefinition src/outlines/types/dsl.py` (1.14.1): no issues found.
- `test_container_of_builtin_generates_parseable_json` runs the generated regex against a real sample for 13 terms and asserts `json.loads` accepts the quoted form and the regex rejects the bare one, so the tests check the output rather than restating the wrapper.
- Verified by hand on 7d06847 and on this branch: `pickle.loads(pickle.dumps(list[types.email]))` and `copy.deepcopy(types.email)` both quote correctly here and did not under an identity check.

The rest of the suite needs `transformers`, which I could not install locally; `tests/test_exceptions.py` and `tests/test_cache.py` report 2 failures and 1 error on 7d06847 unchanged, from a missing async pytest plugin rather than this change.

## AI disclosure

This change was AI-assisted, per CONTRIBUTING.md. I reviewed every line, ran every command quoted above myself, and can explain the whole diff.

