### PR TITLE
fix(types): handle tuple and boolean array items in JSON Schema conversion

### DIFF
--- a/src/outlines/types/json_schema_utils.py
+++ b/src/outlines/types/json_schema_utils.py
@@ -67,9 +67,19 @@ def schema_type_to_python(
         return type(None)
     elif t == "array":
         items = schema.get("items", {})
-        if items:
+        if isinstance(items, list):
+            # Draft-07 tuple validation: ``items`` is a list of per-position
+            # schemas. Model it as a list of any of the member types rather
+            # than recursing into the list itself (which has no ``.get``).
+            members = tuple(
+                schema_type_to_python(member, caller_target_type) for member in items
+            )
+            item_type = Union[members] if members else Any  # type: ignore
+        elif isinstance(items, dict) and items:
             item_type = schema_type_to_python(items, caller_target_type)
         else:
+            # Missing, empty, or boolean ``items`` (2020-12 allows ``true`` /
+            # ``false``): fall back to an unconstrained element type.
             item_type = Any
         return List[item_type]  # type: ignore
     elif t == "object":

--- a/tests/types/test_json_schema_utils.py
+++ b/tests/types/test_json_schema_utils.py
@@ -50,6 +50,34 @@ def test_schema_type_to_python_array():
     assert result == List[Any]
 
 
+def test_schema_type_to_python_array_tuple_items():
+    # Draft-07 tuple validation: items is a list of per-position schemas
+    schema = {"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}
+    result = schema_type_to_python(schema, "pydantic")
+    assert result == List[Union[str, int]]
+
+    # Single-member list collapses to that member type
+    schema = {"type": "array", "items": [{"type": "string"}]}
+    result = schema_type_to_python(schema, "pydantic")
+    assert result == List[str]
+
+    # Empty list has no element type to derive
+    schema = {"type": "array", "items": []}
+    result = schema_type_to_python(schema, "pydantic")
+    assert result == List[Any]
+
+
+def test_schema_type_to_python_array_boolean_items():
+    # JSON Schema 2020-12 allows a boolean items schema
+    schema = {"type": "array", "items": True}
+    result = schema_type_to_python(schema, "pydantic")
+    assert result == List[Any]
+
+    schema = {"type": "array", "items": False}
+    result = schema_type_to_python(schema, "pydantic")
+    assert result == List[Any]
+
+
 def test_schema_type_to_python_object():
     schema = {
         "type": "object",


### PR DESCRIPTION
`schema_type_to_python` assumes `items` is always a single schema dict, so two valid JSON Schema forms crash it before the schema can be converted to a Pydantic/TypedDict/dataclass target.

A draft-07 array with tuple validation — `{"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}` — passes the list straight into the recursive call, which then does `"enum" in schema` / `schema.get(...)` on a `list` and raises `AttributeError: 'list' object has no attribute 'get'`. A 2020-12 boolean items schema — `{"type": "array", "items": true}` — hits the same recursion and raises `TypeError: argument of type 'bool' is not iterable`. Because these can sit on a nested property, one such field takes down the whole conversion.

Handle both in the array branch: a list of positional schemas becomes `List[Union[...]]` of the member types (collapsing to the single type for a one-element list, `List[Any]` for an empty one), and a boolean `items` falls back to `List[Any]` the same way a missing/empty `items` already does. Regular dict items are unchanged. Added tests for the tuple and boolean forms.
