### PR TITLE
Fix async function rendering in the source filter

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -245,7 +245,7 @@ def get_fn_source(fn: Callable):
         raise TypeError("The `source` filter only applies to callables.")
 
     source = textwrap.dedent(inspect.getsource(fn))
-    re_search = re.search(re.compile(r"(\bdef\b.*)", re.DOTALL), source)
+    re_search = re.search(re.compile(r"((?:async\s+)?\bdef\b.*)", re.DOTALL), source)
     if re_search is not None:
         source = re_search.group(0)
     else:  # pragma: no cover

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -384,6 +384,14 @@ def test_get_fn_source():
     assert get_fn_source(sample_function).strip() == source
 
 
+def test_get_fn_source_async_function():
+    async def async_sample_function(x):
+        return x
+
+    source = "async def async_sample_function(x):\n    return x"
+    assert get_fn_source(async_sample_function).strip() == source
+
+
 def test_get_fn_signature():
     with pytest.raises(TypeError, match="The `source` filter only applies to callables."):
         get_fn_signature(1)


### PR DESCRIPTION
## Summary

The template `source` filter searched for the first `def` token when stripping decorators. For asynchronous functions, this dropped the preceding `async` keyword, so templates rendered coroutine functions as synchronous functions and could produce invalid source when the body used `await`.

This change preserves `async def` when extracting callable source and adds a focused regression test.

No matching issue or pull request was found. This is a bug fix rather than a new feature, so the feature-issue requirement does not apply.

## Validation

- `pytest tests/test_templates.py -q` — 18 passed
- Ruff on both changed files — passed
- `mypy --allow-redefinition` on both changed files — passed
- `git diff --check` — passed

This PR was prepared with assistance from OpenAI Codex. I reviewed and understand the implementation and tests and verified the behavior locally.

## Checklist

- [x] The title describes the change
- [x] There is a high-level description of the changes
- [x] All relevant issues, discussions, and pull requests are linked (none found)
- [x] The branch is based on the latest `main` commit
- [x] The commit message follows the project guidelines
- [x] There is one commit for this logical change
- [x] The code follows the current naming conventions
- [x] No new or changed docstrings are required
- [x] Pre-commit was run before opening the PR
- [x] Tests cover the change
- [x] No documentation update is required for this bug fix
