### PR TITLE
fix(ci): add urllib3 to mypy pre-commit additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: mypy
       args: [--allow-redefinition]
       exclude: ^examples/
-      additional_dependencies: [types-tqdm, types-Pillow]
+      additional_dependencies: [types-tqdm, types-Pillow, urllib3]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.9.1
   hooks:


### PR DESCRIPTION
## Problem

The `urllib3` import in `src/outlines/exceptions.py` (line 352, inside the dottxt provider branch) is not resolvable in fresh pre-commit mypy environments because `urllib3` is not a project dependency and is not listed in the mypy hook's `additional_dependencies`. The breakage is masked whenever a stale cached mypy environment (which happens to contain `urllib3`) is reused, which is why main runs can appear green while fresh PR builds fail with:

```
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3.exceptions"  [import-not-found]
src/outlines/exceptions.py:352: error: Cannot find implementation or library stub for module named "urllib3"  [import-not-found]
```

This blocks three open PRs (#2007, #2008, #2010) whose CI fails on the "Check the code style" job.

## Fix

Add `urllib3` to the mypy pre-commit hook's `additional_dependencies` so that fresh environments can resolve the import.

## Test

`pre-commit run --all-files` now passes (mypy finds `urllib3`, ruff passes).