### PR TITLE
fix: don't truncate signature filter on closing parens in defaults

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -257,16 +257,13 @@ def get_fn_source(fn: Callable):
 def get_fn_signature(fn: Callable):
     """Return the signature of a callable."""
     if not callable(fn):
-        raise TypeError("The `source` filter only applies to callables.")
+        raise TypeError("The `signature` filter only applies to callables.")
 
-    source = textwrap.dedent(inspect.getsource(fn))
-    re_search = re.search(re.compile(r"\(([^)]+)\)"), source)
-    if re_search is None:  # pragma: no cover
-        signature = ""
-    else:
-        signature = re_search.group(1)
-
-    return signature
+    # Parsing the source with a regex broke on any `)` inside the parameter
+    # list (tuple defaults, nested calls), truncating the signature. Let
+    # inspect do it correctly, matching the `args` filter.
+    parameters = inspect.signature(fn).parameters.values()
+    return ", ".join(str(param) for param in parameters)
 
 
 @functools.singledispatch

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -34,6 +34,10 @@ def function_with_annotations(x: int, y: str) -> str:
 def function_with_no_docstring(x, y):
     return x * y
 
+def function_with_paren_default(a, b=(1, 2), c="x"):
+    """Function whose default value contains a closing paren."""
+    return a
+
 class CallableClass:
     def __call__(self):
         pass
@@ -385,12 +389,14 @@ def test_get_fn_source():
 
 
 def test_get_fn_signature():
-    with pytest.raises(TypeError, match="The `source` filter only applies to callables."):
+    with pytest.raises(TypeError, match="The `signature` filter only applies to callables."):
         get_fn_signature(1)
     sample_function_signature = "x, y=2"
     assert get_fn_signature(sample_function) == sample_function_signature
     function_with_annotations_signature = "x: int, y: str"
     assert get_fn_signature(function_with_annotations) == function_with_annotations_signature
+    # A closing paren inside a default value used to truncate the signature.
+    assert get_fn_signature(function_with_paren_default) == "a, b=(1, 2), c='x'"
 
 
 def test_get_schema():


### PR DESCRIPTION
The `signature` template filter parses a function's source with `\(([^)]+)\)`, which stops at the first `)`. Any closing paren inside the parameter list — a tuple default, a nested call, an annotation like `Callable[[int], str]` — truncates the result. `def f(a, b=(1, 2), c="x")` renders as `a, b=(1, 2`, silently dropping `c`.

Switched it to `inspect.signature`, the same approach the neighbouring `args` filter already uses, so the parameter list is read from the signature object instead of scraped from text. Also fixed the error message, which mentioned the `source` filter by mistake.

Added a test with a paren-containing default and updated the existing one for the corrected message. `tests/test_templates.py` passes.
