### PR TITLE
[Fix] Preserve whitespace_pattern in SGLangTypeAdapter extra_body

### DIFF
--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -75,9 +75,14 @@ class SGLangTypeAdapter(ModelTypeAdapter):
             )
             return {"extra_body": {"ebnf": term.definition}}
         elif isinstance(term, JsonSchema):
-            return OpenAITypeAdapter().format_json_output_type(
+            output_dict = OpenAITypeAdapter().format_json_output_type(
                 json.loads(term.schema)
             )
+            if term.whitespace_pattern is not None:
+                output_dict.setdefault("extra_body", {})["whitespace_pattern"] = (
+                    term.whitespace_pattern
+                )
+            return output_dict
         else:
             return {"extra_body": {"regex": to_regex(term)}}
 

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -149,7 +149,7 @@ def test_sglang_type_adapter_output_type(
             },
         }
     }
-    # whitespace pattern is ignored
+    # whitespace pattern is preserved in extra_body
     assert type_adapter.format_output_type(json_schema_whitespace_instance) == {
         "response_format": {
             "type": "json_schema",
@@ -161,7 +161,8 @@ def test_sglang_type_adapter_output_type(
                     "additionalProperties": False,
                 },
             },
-        }
+        },
+        "extra_body": {"whitespace_pattern": "\n"},
     }
     assert type_adapter.format_output_type(int) == {
         "extra_body": {"regex": "([+-]?(0|[1-9][0-9]*))"}


### PR DESCRIPTION
## Description
Fixes #1998

When passing a `JsonSchema` with a custom `whitespace_pattern` to `SGLangTypeAdapter.format_output_type`, `whitespace_pattern` was previously omitted, causing the SGLang server to use default whitespace rather than respecting the requested format (such as compact single-line JSON or custom newlines).

This PR:
1. Updates `SGLangTypeAdapter.format_output_type` to pass `whitespace_pattern` in `extra_body` when `term.whitespace_pattern is not None`.
2. Updates `tests/models/test_sglang_type_adapter.py` to verify `whitespace_pattern` is correctly preserved in `extra_body`.