### PR TITLE
fix: reject falsy output types in MLXLM batch generation

### DIFF
--- a/src/outlines/models/mlxlm.py
+++ b/src/outlines/models/mlxlm.py
@@ -198,7 +198,7 @@ class MLXLM(Model):
         """
         from mlx_lm import batch_generate
 
-        if output_type:
+        if output_type is not None:
             raise NotImplementedError(
                 "mlx-lm does not support constrained generation with batching."
                 + "You cannot provide an `output_type` with this method."

--- a/tests/models/test_mlxlm.py
+++ b/tests/models/test_mlxlm.py
@@ -1,5 +1,7 @@
 import pytest
 import re
+import sys
+from types import ModuleType
 from enum import Enum
 from typing import Generator
 
@@ -155,3 +157,22 @@ def test_mlxlm_batch_output_type(model):
             ["Respond with one word.", "Respond with one word."],
             Regex(r"[0-9]")
         )
+
+
+def test_mlxlm_batch_rejects_falsy_output_type(monkeypatch):
+    """Batch generation rejects output types even when their truth value is false."""
+    fake_mlx_lm = ModuleType("mlx_lm")
+    fake_mlx_lm.batch_generate = lambda *args, **kwargs: []
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+
+    model = object.__new__(MLXLM)
+
+    class FalsyOutputType:
+        def __bool__(self):
+            return False
+
+    with pytest.raises(
+        NotImplementedError,
+        match="mlx-lm does not support constrained generation with batching.",
+    ):
+        model.generate_batch([], FalsyOutputType())


### PR DESCRIPTION
## Summary

Fixes #1997.

`MLXLM.generate_batch` used a truthiness check for `output_type`. A valid output type object whose `__bool__` returns `False` bypassed the unsupported-feature guard and reached unconstrained batch generation. The guard now checks identity against `None`, matching the other MLXLM generation entry points.

## Changes

- Use `output_type is not None` in `MLXLM.generate_batch`.
- Add a deterministic regression test that invokes the real method with a falsy, non-`None` output type and a stubbed local `mlx_lm` module.

## Validation

- `git diff --check`: passed.
- `uv run --frozen pytest tests/models/test_mlxlm.py -q`: collection blocked because `transformers` was not installed in the fresh frozen environment.
- `uv sync --extra test --frozen`: attempted, but the large dependency installation did not complete in the available time and was stopped.
- `uvx --from ruff ruff check ...`: reports existing baseline lint findings in the touched files; no unrelated cleanup was included.

The regression test does not require Apple Silicon or a real model; it only stubs the optional `mlx_lm.batch_generate` import and exercises `MLXLM.generate_batch` directly.

## Bot-style preflight review

- Acceptance condition: covered by the identity check and falsy-object regression test.
- Existing behavior: `None` still proceeds to normal batch generation; non-`None` values are rejected before generation.
- Other entry points: `generate` and `stream` already use the type adapter's existing handling; this issue is specific to the batch guard.
- Resource/concurrency/serialization impact: none; the change only affects the unsupported output-type validation branch.
- Test isolation: the optional module is installed in `sys.modules` through pytest's monkeypatch fixture and restored automatically.