### PR TITLE
fix: preserve SGLang JSON whitespace pattern

### DIFF
--- a/src/outlines/models/sglang.py
+++ b/src/outlines/models/sglang.py
@@ -75,9 +75,14 @@ class SGLangTypeAdapter(ModelTypeAdapter):
             )
             return {"extra_body": {"ebnf": term.definition}}
         elif isinstance(term, JsonSchema):
-            return OpenAITypeAdapter().format_json_output_type(
+            structured_outputs = OpenAITypeAdapter().format_json_output_type(
                 json.loads(term.schema)
             )
+            if term.whitespace_pattern:
+                structured_outputs["response_format"]["whitespace_pattern"] = (
+                    term.whitespace_pattern
+                )
+            return structured_outputs
         else:
             return {"extra_body": {"regex": to_regex(term)}}
 

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from PIL import Image as PILImage
 
 from outlines.inputs import Chat, Image
-from outlines.models.sglang import SGLangTypeAdapter
+from outlines.models.sglang import SGLang, SGLangTypeAdapter
 from outlines.types import CFG, JsonSchema
 
 
@@ -166,3 +166,15 @@ def test_sglang_type_adapter_output_type(
     assert type_adapter.format_output_type(int) == {
         "extra_body": {"regex": "([+-]?(0|[1-9][0-9]*))"}
     }
+
+
+def test_sglang_build_client_args_preserves_whitespace_pattern(
+    json_schema_whitespace_instance,
+):
+    model = SGLang(client=object(), model_name="test-model")
+
+    client_args = model._build_client_args(
+        "prompt", json_schema_whitespace_instance
+    )
+
+    assert client_args["response_format"]["whitespace_pattern"] == "\n"

--- a/tests/models/test_sglang_type_adapter.py
+++ b/tests/models/test_sglang_type_adapter.py
@@ -149,9 +149,9 @@ def test_sglang_type_adapter_output_type(
             },
         }
     }
-    # whitespace pattern is ignored
     assert type_adapter.format_output_type(json_schema_whitespace_instance) == {
         "response_format": {
+            "whitespace_pattern": "\n",
             "type": "json_schema",
             "json_schema": {
                 "name": "default",


### PR DESCRIPTION
## Summary

SGLang currently drops `whitespace_pattern` when formatting JSON schema structured outputs. This change preserves the configured pattern and forwards it in the request payload.

## Testing

- Added regression coverage for JSON schema whitespace patterns in the SGLang type adapter.
- Verified the existing payload behavior remains unchanged when no pattern is configured.

Closes #1998