### PR TITLE
fix: normalize indented trailing template lines

### DIFF
--- a/src/outlines/templates.py
+++ b/src/outlines/templates.py
@@ -126,11 +126,11 @@ def build_template_from_string(
     content: str, filters: Dict[str, Callable] = {}
 ) -> jinja2.Template:
     # Dedent, and remove extra linebreak
-    cleaned_template = inspect.cleandoc(content)
+    cleaned_template = inspect.cleandoc(content).rstrip()
 
     # Add linebreak if there were any extra linebreaks that
     # `cleandoc` would have removed
-    ends_with_linebreak = content.replace(" ", "").endswith("\n\n")
+    ends_with_linebreak = re.search(r"\n[^\S\r\n]*\n\s*$", content) is not None
     if ends_with_linebreak:
         cleaned_template += "\n"
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -348,6 +348,13 @@ def test_template_from_str_with_extra_linebreaks():
     assert template.render(name="World") == "Hello, World!\n"
 
 
+@pytest.mark.parametrize("indentation", ["        ", "\t"])
+def test_template_from_str_with_indented_trailing_blank_line(indentation):
+    content = f"\n    Hello, {{{{ name }}}}!\n\n\n{indentation}"
+    template = build_template_from_string(content)
+    assert template.render(name="World") == "Hello, World!\n"
+
+
 def test_get_fn_name():
     with pytest.raises(TypeError):
         get_fn_name(1)


### PR DESCRIPTION
Closes #1985\n\n## Summary\n- normalize trailing whitespace after dedenting templates\n- detect trailing blank lines containing any horizontal whitespace\n- add regression coverage for over-indented spaces and tabs\n\n## Validation\n- $env:PYTHONPATH='src'; uv run --frozen python -m pytest tests/test_templates.py -q (19 passed)\n- git diff --check passed\n- Ruff was run; it reports pre-existing import/style issues in the touched files.