### PR TITLE
docs(llamacpp): note that local runtime bypasses exception normalization

### DIFF
--- a/src/outlines/models/llamacpp.py
+++ b/src/outlines/models/llamacpp.py
@@ -1,4 +1,8 @@
-"""Integration with the `llama-cpp-python` library."""
+"""Integration with the `llama-cpp-python` library.
+
+Local runtime calls intentionally bypass
+outlines.exceptions.normalize_provider_errors().
+"""
 
 import ctypes
 from functools import singledispatchmethod


### PR DESCRIPTION
## Context
#1823 implemented the uniform provider exception hierarchy requested in #1658. As part of that work, every local-runtime model file was given a short module docstring note explaining that it intentionally bypasses `outlines.exceptions.normalize_provider_errors()` (since local runtimes raise native errors, not provider-API errors) - see `mlxlm.py`, `transformers.py`, and `vllm_offline.py`.

`llamacpp.py` is also a local runtime (per `docs/features/models/index.md`, it's listed alongside MLXLM/Transformers as one of the "local models"), but it was missed and never got this note.

## Change
Adds the same bypass note to `llamacpp.py`'s module docstring, matching the existing convention exactly. No logic changes.

With this, every model provider file now explicitly documents its exception-handling stance (normalized or intentionally bypassed), closing out the last remaining gap from #1658.

## Verification
- `python -m py_compile src/outlines/models/llamacpp.py` - passes.
- Docstring-only change; no behavior affected.

Closes #1658