### PR TITLE
Raise clear error for unsupported parametrized set types

### DIFF
--- a/src/outlines/types/dsl.py
+++ b/src/outlines/types/dsl.py
@@ -26,6 +26,7 @@ from typing import (
     Optional as OptionalType,
     Union,
     get_args,
+    get_origin,
 )
 import jsonschema
 from genson import SchemaBuilder
@@ -817,7 +818,13 @@ def python_types_to_terms(ptype: Any, recursion_depth: int = 0) -> Term:
     elif is_typing_dict(ptype):
         return _handle_dict(args, recursion_depth)
 
-    if is_callable(ptype):
+    # Only treat ``ptype`` as a callable (function/class signature) when it is
+    # not a parametrized generic. Parametrized generics such as ``set[int]`` or
+    # ``Set[int]`` are ``callable()`` yet unsupported here; without this guard
+    # they fall into the callable branch and raise the misleading
+    # "Each argument must have a type annotation" instead of the clear
+    # "Type ... is currently not supported" error below.
+    if get_origin(ptype) is None and is_callable(ptype):
         return JsonSchema(get_schema_from_signature(ptype))
 
     type_name = getattr(ptype, "__name__", ptype)

--- a/tests/types/test_dsl.py
+++ b/tests/types/test_dsl.py
@@ -6,7 +6,9 @@ import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
+    FrozenSet,
     Literal,
+    Set,
     Tuple,
     Union,
     get_args,
@@ -673,6 +675,14 @@ def test_dsl_python_types_to_terms():
     # type not supported
     with pytest.raises(TypeError, match="is currently not supported"):
         python_types_to_terms(bytes)
+
+    # Unsupported *parametrized* generics (e.g. ``set[int]``) are ``callable()``
+    # but are not a function/class signature, so they must raise the same clear
+    # "is currently not supported" TypeError as their bare counterparts rather
+    # than the misleading "Each argument must have a type annotation" ValueError.
+    for unsupported in (set[int], Set[int], FrozenSet[str], frozenset[int]):
+        with pytest.raises(TypeError, match="is currently not supported"):
+            python_types_to_terms(unsupported)
 
 
 def test_dsl_enum_with_instance_method_is_not_a_choice():


### PR DESCRIPTION
## What this does

`python_types_to_terms` raises a misleading error for unsupported *parametrized* set-like generics.

```python
from typing import Set, FrozenSet
from outlines.types.dsl import python_types_to_terms

python_types_to_terms(set[int])       # ValueError: Each argument must have a type annotation
python_types_to_terms(Set[int])       # ValueError: Each argument must have a type annotation
python_types_to_terms(FrozenSet[str]) # ValueError: Each argument must have a type annotation
```

The bare types already raise the intended, clear error:

```python
python_types_to_terms(set)   # TypeError: Type set is currently not supported. Please open an issue: ...
```

## Root cause

Parametrized generics like `set[int]` are `callable()` but are **not** a type (`isinstance(set[int], type)` is `False`), so `is_callable(...)` returns `True`. They fall into the callable branch, which calls `get_schema_from_signature(...)` and raises `ValueError: Each argument must have a type annotation` — an error that has nothing to do with the actual problem (an unsupported container type).

## Fix

Gate the callable branch with `get_origin(ptype) is None` so parametrized generics skip it and reach the clear `TypeError: Type ... is currently not supported` error, matching the behavior of their bare counterparts.

## Testing

Added a regression test next to the existing `bytes` assertion in `test_dsl_python_types_to_terms`, covering `set[int]`, `Set[int]`, `FrozenSet[str]` and `frozenset[int]`. It fails before the fix (with the misleading `ValueError`) and passes after.

- `pytest tests/types/` — 346 passed
- `ruff check --config=pyproject.toml` (v0.9.1) — clean
- `mypy --allow-redefinition src/outlines/types/dsl.py` — clean