### PR TITLE
Scope cache_disabled() to the current context so it cannot leak acros…

### DIFF
--- a/src/outlines/caching.py
+++ b/src/outlines/caching.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import contextvars
 import functools
 import os
 import tempfile
@@ -12,6 +13,17 @@ from diskcache import Cache, Disk
 from diskcache.core import ENOVAL, UNKNOWN, args_to_key, full_name
 
 _caching_enabled = True
+
+# Set by `cache_disabled()`. A ContextVar rather than a plain global so that
+# disabling the cache inside one task does not leak into concurrent tasks
+# that never opted in.
+_cache_disabled_scope: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "outlines_cache_disabled_scope", default=False
+)
+
+
+def _cache_is_enabled() -> bool:
+    return _caching_enabled and not _cache_disabled_scope.get()
 
 
 class CloudpickleDisk(Disk): # pragma: no cover
@@ -113,7 +125,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         if asyncio.iscoroutinefunction(cached_function):  # pragma: no cover
 
             async def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _cache_is_enabled():
                     return await cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -128,7 +140,7 @@ def cache(expire: Optional[float] = None, typed=False, ignore=()):
         else:
 
             def wrapper(*args, **kwargs):
-                if not _caching_enabled:
+                if not _cache_is_enabled():
                     return cached_function(*args, **kwargs)
 
                 cache_key = wrapper.__cache_key__(*args, **kwargs)
@@ -185,11 +197,8 @@ def clear_cache():
 
 @contextlib.contextmanager
 def cache_disabled():
-    # outlines.caching._caching_enabled
-    global _caching_enabled
-    original_state = _caching_enabled
-    _caching_enabled = False
+    token = _cache_disabled_scope.set(True)
     try:
         yield
     finally:
-        _caching_enabled = original_state
+        _cache_disabled_scope.reset(token)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import tempfile
 import unittest
@@ -198,6 +199,40 @@ def test_cache_disabled_decorator(test_cache):
     # scope has exited, cache is enabled again
     fn()
     assert mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_disabled_does_not_leak_across_tasks(test_cache):
+    """cache_disabled() in one task must not disable the cache for other tasks"""
+
+    from outlines.caching import cache_disabled
+
+    calls = []
+
+    @test_cache
+    def fn():
+        calls.append(1)
+        return 1
+
+    fn()
+    assert len(calls) == 1
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        with cache_disabled():
+            entered.set()
+            await release.wait()
+
+    async def other_task():
+        await entered.wait()
+        fn()  # never opted out, so this should still be served from the cache
+        release.set()
+
+    await asyncio.gather(holder(), other_task())
+
+    assert len(calls) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
…s tasks

cache_disabled() flipped a module-level global, so a coroutine that entered it and then awaited left the cache disabled for every other coroutine running on the same event loop. Those coroutines never opted out, but silently recomputed instead of reading the cache.

Move the scoped override to a ContextVar. Tasks get a copy of the context at creation time, so the override stays with the task that set it. disable_cache() keeps using the module global, since that switch is meant to be process-wide.